### PR TITLE
refactor: loading state

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -302,6 +302,29 @@ dependencies = [
 ]
 
 [[package]]
+name = "bevy_asset_loader"
+version = "0.12.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "91275716531c98d9907ee8c57854d11e3688780a9cefc66b1d4da601a3e3c41e"
+dependencies = [
+ "anyhow",
+ "bevy",
+ "bevy_asset_loader_derive",
+ "iyes_loopless",
+]
+
+[[package]]
+name = "bevy_asset_loader_derive"
+version = "0.12.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e721755806423f711c0934295872808adb20d379b3073c679ed544960fc84b6d"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn",
+]
+
+[[package]]
 name = "bevy_audio"
 version = "0.8.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2005,6 +2028,18 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "6c8af84674fe1f223a982c933a0ee1086ac4d4052aa0fb8060c12c6ad838e754"
 
 [[package]]
+name = "iyes_loopless"
+version = "0.7.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "fec251a82c60be9e282aec12056fa153666d5730b21d124655d7c22114d342c8"
+dependencies = [
+ "bevy_app",
+ "bevy_ecs",
+ "bevy_time",
+ "bevy_utils",
+]
+
+[[package]]
 name = "jni"
 version = "0.19.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3538,8 +3573,10 @@ version = "0.3.1"
 dependencies = [
  "bevy",
  "bevy-inspector-egui",
+ "bevy_asset_loader",
  "bevy_easings",
  "bevy_ecs_ldtk",
+ "iyes_loopless",
  "rand",
  "serde",
 ]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -19,9 +19,9 @@ bevy_easings = "0.8"
 bevy_ecs_ldtk = "0.4"
 rand = "0.8"
 serde = "1.0"
-
+bevy_asset_loader = { version = "0.12", features = ["stageless"] }
+iyes_loopless = "0.7"
 bevy-inspector-egui = { version = "0.12", optional = true }
 
 [target.wasm32-unknown-unknown.dependencies]
 bevy_ecs_ldtk = { version = "0.4", features = ["atlas"] }
-

--- a/src/gameplay/transitions.rs
+++ b/src/gameplay/transitions.rs
@@ -3,11 +3,12 @@ use crate::{
     gameplay::{components::*, systems::schedule_level_card, LevelCardEvent},
     resources::*,
     sugar::GoalGhostAnimation,
-    LevelState,
+    GameState,
 };
 use bevy::{prelude::*, window::WindowResized};
 use bevy_easings::*;
 use bevy_ecs_ldtk::{ldtk::FieldInstance, prelude::*};
+use iyes_loopless::prelude::*;
 use rand::{distributions::WeightedIndex, prelude::*};
 use std::time::Duration;
 
@@ -392,7 +393,6 @@ pub fn spawn_level_card(
 pub fn level_card_update(
     mut commands: Commands,
     mut card_query: Query<(Entity, &mut LevelCard, &mut Style)>,
-    mut level_state: ResMut<LevelState>,
     mut level_card_events: EventReader<LevelCardEvent>,
 ) {
     for event in level_card_events.iter() {
@@ -417,7 +417,7 @@ pub fn level_card_update(
                         },
                     ));
 
-                    *level_state = LevelState::Gameplay;
+                    commands.insert_resource(NextState(GameState::Gameplay));
                     *card = LevelCard::Falling;
                 }
                 LevelCardEvent::Despawn => {

--- a/src/gameplay/transitions.rs
+++ b/src/gameplay/transitions.rs
@@ -435,70 +435,64 @@ pub fn fit_camera_around_play_zone_padded(
         (&mut Transform, &mut OrthographicProjection),
         With<OrthographicCamera>,
     >,
-    mut level_events: EventReader<LevelEvent>,
-    window_resize_events: EventReader<WindowResized>,
     level_query: Query<&Handle<LdtkLevel>>,
     levels: Res<Assets<LdtkLevel>>,
     windows: Res<Windows>,
     play_zone_portion: Res<PlayZonePortion>,
 ) {
-    if !window_resize_events.is_empty()
-        || level_events
-            .iter()
-            .any(|e| matches!(e, LevelEvent::Transformed(_)))
-    {
-        if let Ok(level_handle) = level_query.get_single() {
-            if let Some(level) = levels.get(level_handle) {
-                let level_size = IVec2::new(level.level.px_wid, level.level.px_hei);
-                let padded_level_size = level_size + IVec2::splat(32 * 2);
+    if let Ok(level_handle) = level_query.get_single() {
+        println!("level entity found");
+        if let Some(level) = levels.get(level_handle) {
+            println!("level asset found");
+            let level_size = IVec2::new(level.level.px_wid, level.level.px_hei);
+            let padded_level_size = level_size + IVec2::splat(32 * 2);
 
-                let window = windows.primary();
+            let window = windows.primary();
 
-                let padded_level_ratio = padded_level_size.x as f32 / padded_level_size.y as f32;
-                let aspect_ratio = window.width() as f32 / window.height() as f32;
-                let play_zone_ratio = aspect_ratio * **play_zone_portion;
+            let padded_level_ratio = padded_level_size.x as f32 / padded_level_size.y as f32;
+            let aspect_ratio = window.width() as f32 / window.height() as f32;
+            let play_zone_ratio = aspect_ratio * **play_zone_portion;
 
-                let (mut transform, mut projection) = camera_query.single_mut();
-                projection.scaling_mode = bevy::render::camera::ScalingMode::None;
-                projection.bottom = 0.;
-                projection.left = 0.;
+            let (mut transform, mut projection) = camera_query.single_mut();
+            projection.scaling_mode = bevy::render::camera::ScalingMode::None;
+            projection.bottom = 0.;
+            projection.left = 0.;
 
-                let play_zone_size = if padded_level_ratio > play_zone_ratio {
-                    // Level is "wide"
-                    Size {
-                        width: padded_level_size.x as f32,
-                        height: padded_level_size.x as f32 / play_zone_ratio,
-                    }
-                } else {
-                    // Level is "tall"
-                    Size {
-                        width: padded_level_size.y as f32 * play_zone_ratio,
-                        height: padded_level_size.y as f32,
-                    }
-                };
+            let play_zone_size = if padded_level_ratio > play_zone_ratio {
+                // Level is "wide"
+                Size {
+                    width: padded_level_size.x as f32,
+                    height: padded_level_size.x as f32 / play_zone_ratio,
+                }
+            } else {
+                // Level is "tall"
+                Size {
+                    width: padded_level_size.y as f32 * play_zone_ratio,
+                    height: padded_level_size.y as f32,
+                }
+            };
 
-                if play_zone_ratio > aspect_ratio {
-                    // Play zone is "wide"
-                    let pixel_perfect_width =
-                        ((play_zone_size.width / aspect_ratio).round() * aspect_ratio).round();
+            if play_zone_ratio > aspect_ratio {
+                // Play zone is "wide"
+                let pixel_perfect_width =
+                    ((play_zone_size.width / aspect_ratio).round() * aspect_ratio).round();
 
-                    projection.right = pixel_perfect_width as f32;
-                    projection.top = (pixel_perfect_width as f32 / aspect_ratio).round();
-                } else {
-                    // Play zone is "tall"
+                projection.right = pixel_perfect_width as f32;
+                projection.top = (pixel_perfect_width as f32 / aspect_ratio).round();
+            } else {
+                // Play zone is "tall"
 
-                    let pixel_perfect_height =
-                        ((play_zone_size.height / aspect_ratio).round() * aspect_ratio).round();
+                let pixel_perfect_height =
+                    ((play_zone_size.height / aspect_ratio).round() * aspect_ratio).round();
 
-                    projection.right = (pixel_perfect_height as f32 * aspect_ratio).round();
-                    projection.top = pixel_perfect_height as f32;
-                };
+                projection.right = (pixel_perfect_height as f32 * aspect_ratio).round();
+                projection.top = pixel_perfect_height as f32;
+            };
 
-                transform.translation.x =
-                    ((play_zone_size.width - padded_level_size.x as f32) / -2.).round();
-                transform.translation.y =
-                    ((play_zone_size.height - padded_level_size.y as f32) / -2.).round();
-            }
+            transform.translation.x =
+                ((play_zone_size.width - padded_level_size.x as f32) / -2.).round();
+            transform.translation.y =
+                ((play_zone_size.height - padded_level_size.y as f32) / -2.).round();
         }
     }
 }

--- a/src/gameplay/transitions.rs
+++ b/src/gameplay/transitions.rs
@@ -443,9 +443,7 @@ pub fn fit_camera_around_play_zone_padded(
     play_zone_portion: Res<PlayZonePortion>,
 ) {
     if let Ok(level_handle) = level_query.get_single() {
-        println!("level entity found");
         if let Some(level) = levels.get(level_handle) {
-            println!("level asset found");
             let level_size = IVec2::new(level.level.px_wid, level.level.px_hei);
             let padded_level_size = level_size + IVec2::splat(32 * 2);
 

--- a/src/gameplay/transitions.rs
+++ b/src/gameplay/transitions.rs
@@ -3,25 +3,19 @@ use crate::{
     gameplay::{components::*, systems::schedule_level_card, LevelCardEvent},
     resources::*,
     sugar::GoalGhostAnimation,
-    GameState,
+    AssetHolder, GameState,
 };
-use bevy::{prelude::*, window::WindowResized};
+use bevy::prelude::*;
 use bevy_easings::*;
 use bevy_ecs_ldtk::{ldtk::FieldInstance, prelude::*};
 use iyes_loopless::prelude::*;
 use rand::{distributions::WeightedIndex, prelude::*};
 use std::time::Duration;
 
-pub fn world_setup(mut commands: Commands, asset_server: Res<AssetServer>) {
+pub fn spawn_camera(mut commands: Commands) {
     commands
         .spawn_bundle(Camera2dBundle::default())
         .insert(OrthographicCamera);
-
-    commands.spawn_bundle(LdtkWorldBundle {
-        ldtk_handle: asset_server.load("levels/sokoban-sokoban.ldtk"),
-        transform: Transform::from_xyz(32., 32., 0.),
-        ..Default::default()
-    });
 }
 
 pub fn spawn_gravestone_body(
@@ -250,15 +244,23 @@ pub fn schedule_first_level_card(
 }
 
 pub fn load_next_level(
+    mut commands: Commands,
     mut level_card_events: EventReader<LevelCardEvent>,
     mut level_selection: ResMut<LevelSelection>,
     mut first_card_skipped: Local<bool>,
+    asset_holder: Res<AssetHolder>,
 ) {
     for event in level_card_events.iter() {
         if let LevelCardEvent::Block(new_level_selection) = event {
             if *first_card_skipped {
                 *level_selection = new_level_selection.clone()
             } else {
+                commands.spawn_bundle(LdtkWorldBundle {
+                    ldtk_handle: asset_holder.ldtk.clone(),
+                    transform: Transform::from_xyz(32., 32., 0.),
+                    ..Default::default()
+                });
+
                 *first_card_skipped = true;
             }
         }

--- a/src/main.rs
+++ b/src/main.rs
@@ -13,8 +13,10 @@ mod sugar;
 use animation::{FromComponentAnimator, SpriteSheetAnimationPlugin};
 use bevy::{prelude::*, render::texture::ImageSettings};
 
+use bevy_asset_loader::prelude::*;
 use bevy_easings::EasingsPlugin;
 use bevy_ecs_ldtk::prelude::*;
+use iyes_loopless::prelude::*;
 use rand::Rng;
 
 pub const UNIT_LENGTH: f32 = 32.;
@@ -31,9 +33,10 @@ pub enum SystemLabels {
 }
 
 #[derive(Copy, Clone, Eq, PartialEq, Debug, Hash)]
-pub enum LevelState {
+pub enum GameState {
+    AssetLoading,
+    LevelTransition,
     Gameplay,
-    Inbetween,
 }
 
 fn main() {
@@ -51,6 +54,12 @@ fn main() {
         .add_plugin(SpriteSheetAnimationPlugin)
         .add_plugin(FromComponentAnimator::<sugar::PlayerAnimationState>::new())
         .add_event::<animation::AnimationEvent>()
+        .add_loopless_state(GameState::AssetLoading)
+        .add_loading_state(
+            LoadingState::new(GameState::AssetLoading)
+                .continue_to_state(GameState::LevelTransition)
+                .with_collection::<AssetHolder>(),
+        )
         .add_event::<gameplay::PlayerMovementEvent>()
         .add_event::<history::HistoryCommands>()
         .add_event::<gameplay::DeathEvent>()
@@ -64,56 +73,73 @@ fn main() {
         })
         .insert_resource(Msaa { samples: 1 })
         .insert_resource(LevelSelection::Index(level_num))
-        .insert_resource(LevelState::Inbetween)
         .insert_resource(resources::GoalGhostSettings::NORMAL)
         .insert_resource(resources::RewindSettings::NORMAL)
         .insert_resource(resources::PlayZonePortion(0.75))
-        .add_startup_system_to_stage(StartupStage::PreStartup, sound_load)
         .add_startup_system(gameplay::transitions::world_setup)
         .add_startup_system(gameplay::transitions::spawn_ui_root)
         .add_startup_system(gameplay::transitions::schedule_first_level_card)
         .add_system_to_stage(CoreStage::PreUpdate, sugar::make_ui_visible)
+        .add_system_to_stage(CoreStage::PreUpdate, sugar::reset_player_easing)
+        .add_system_set(
+            ConditionSet::new()
+                .run_in_state(GameState::LevelTransition)
+                .with_system(gameplay::transitions::spawn_level_card)
+                .with_system(gameplay::transitions::spawn_gravestone_body)
+                .with_system(gameplay::transitions::spawn_control_display)
+                .with_system(gameplay::transitions::load_next_level)
+                .with_system(gameplay::transitions::level_card_update)
+                .with_system(gameplay::transitions::fit_camera_around_play_zone_padded)
+                .with_system(gameplay::transitions::spawn_goal_ghosts)
+                .into(),
+        )
+        .add_system(
+            gameplay::systems::move_table_update
+                .run_in_state(GameState::Gameplay)
+                .before(SystemLabels::Input),
+        )
         .add_system(
             gameplay::systems::player_state_input
+                .run_in_state(GameState::Gameplay)
                 .label(SystemLabels::Input)
                 .before(history::FlushHistoryCommands),
         )
-        .add_system(gameplay::systems::move_table_update.before(SystemLabels::Input))
         .add_system(
             gameplay::systems::perform_grid_coords_movement
+                .run_in_state(GameState::Gameplay)
                 .label(SystemLabels::MoveTableUpdate)
                 .before(from_component::FromComponentLabel),
         )
         .add_system(
             gameplay::systems::check_death
+                .run_in_state(GameState::Gameplay)
                 .label(SystemLabels::CheckDeath)
                 .after(history::FlushHistoryCommands),
         )
-        .add_system(gameplay::systems::check_goal.after(SystemLabels::CheckDeath))
         .add_system(
-            history::flush_history_commands::<GridCoords>.label(history::FlushHistoryCommands),
+            history::flush_history_commands::<GridCoords>
+                .run_in_state(GameState::Gameplay)
+                .label(history::FlushHistoryCommands),
+        )
+        .add_system(
+            gameplay::systems::check_goal
+                .run_in_state(GameState::Gameplay)
+                .after(SystemLabels::CheckDeath),
         )
         .add_system(
             gameplay::systems::move_player_by_table
+                .run_in_state(GameState::Gameplay)
                 .after(SystemLabels::MoveTableUpdate)
                 .after(history::FlushHistoryCommands),
         )
-        .add_system(sugar::ease_movement)
-        .add_system_to_stage(CoreStage::PreUpdate, sugar::reset_player_easing)
-        .add_system(gameplay::systems::update_control_display)
-        .add_system(gameplay::transitions::spawn_gravestone_body)
-        .add_system(gameplay::transitions::spawn_control_display)
-        .add_system(gameplay::transitions::spawn_death_card)
-        .add_system(gameplay::transitions::spawn_level_card)
-        .add_system(gameplay::transitions::load_next_level)
-        .add_system(gameplay::transitions::level_card_update)
-        .add_system(gameplay::transitions::fit_camera_around_play_zone_padded)
-        .add_system(gameplay::transitions::spawn_goal_ghosts)
-        .add_system(sugar::goal_ghost_animation)
-        .add_system(sugar::goal_ghost_event_sugar)
-        .add_system(sugar::animate_grass_system)
-        .add_system(sugar::play_death_animations)
-        .add_system(sugar::history_sugar)
+        .add_system(gameplay::transitions::spawn_death_card.run_in_state(GameState::Gameplay))
+        .add_system(gameplay::systems::update_control_display.run_in_state(GameState::Gameplay))
+        .add_system(sugar::ease_movement.run_in_state(GameState::Gameplay))
+        .add_system(sugar::goal_ghost_animation.run_not_in_state(GameState::AssetLoading))
+        .add_system(sugar::goal_ghost_event_sugar.run_not_in_state(GameState::AssetLoading))
+        .add_system(sugar::animate_grass_system.run_not_in_state(GameState::AssetLoading))
+        .add_system(sugar::play_death_animations.run_not_in_state(GameState::AssetLoading))
+        .add_system(sugar::history_sugar.run_not_in_state(GameState::AssetLoading))
         .register_ldtk_entity::<bundles::PlayerBundle>("Willo")
         .register_ldtk_entity::<bundles::InputBlockBundle>("W")
         .register_ldtk_entity::<bundles::InputBlockBundle>("A")
@@ -141,18 +167,16 @@ fn main() {
     app.run()
 }
 
-pub struct SoundEffects {
-    pub victory: Handle<AudioSource>,
-    pub push: Handle<AudioSource>,
-    pub undo: Handle<AudioSource>,
-}
-
-pub fn sound_load(mut commands: Commands, assets: Res<AssetServer>) {
-    commands.insert_resource(SoundEffects {
-        victory: assets.load("sfx/victory.wav"),
-        push: assets.load("sfx/push.wav"),
-        undo: assets.load("sfx/undo.wav"),
-    })
+#[derive(Debug, Default, AssetCollection)]
+pub struct AssetHolder {
+    #[asset(path = "levels/sokoban-sokoban.ldtk")]
+    pub ldtk: Handle<LdtkAsset>,
+    #[asset(path = "sfx/victory.wav")]
+    pub victory_sound: Handle<AudioSource>,
+    #[asset(path = "sfx/push.wav")]
+    pub push_sound: Handle<AudioSource>,
+    #[asset(path = "sfx/undo.wav")]
+    pub undo_sound: Handle<AudioSource>,
 }
 
 #[cfg(feature = "hot")]

--- a/src/main.rs
+++ b/src/main.rs
@@ -68,7 +68,7 @@ fn main() {
             gameplay::LevelCardEvent,
         >::new())
         .insert_resource(LdtkSettings {
-            set_clear_color: SetClearColor::FromLevelBackground,
+            set_clear_color: SetClearColor::FromEditorBackground,
             ..default()
         })
         .insert_resource(Msaa { samples: 1 })
@@ -76,7 +76,7 @@ fn main() {
         .insert_resource(resources::GoalGhostSettings::NORMAL)
         .insert_resource(resources::RewindSettings::NORMAL)
         .insert_resource(resources::PlayZonePortion(0.75))
-        .add_startup_system(gameplay::transitions::world_setup)
+        .add_startup_system(gameplay::transitions::spawn_camera)
         .add_startup_system(gameplay::transitions::spawn_ui_root)
         .add_startup_system(gameplay::transitions::schedule_first_level_card)
         .add_system_to_stage(CoreStage::PreUpdate, sugar::make_ui_visible)

--- a/src/main.rs
+++ b/src/main.rs
@@ -81,6 +81,15 @@ fn main() {
         .add_startup_system(gameplay::transitions::schedule_first_level_card)
         .add_system_to_stage(CoreStage::PreUpdate, sugar::make_ui_visible)
         .add_system_to_stage(CoreStage::PreUpdate, sugar::reset_player_easing)
+        .add_enter_system(
+            GameState::Gameplay,
+            gameplay::transitions::fit_camera_around_play_zone_padded,
+        )
+        .add_system(
+            gameplay::transitions::fit_camera_around_play_zone_padded
+                .run_not_in_state(GameState::AssetLoading)
+                .run_on_event::<bevy::window::WindowResized>(),
+        )
         .add_system_set(
             ConditionSet::new()
                 .run_in_state(GameState::LevelTransition)
@@ -89,7 +98,6 @@ fn main() {
                 .with_system(gameplay::transitions::spawn_control_display)
                 .with_system(gameplay::transitions::load_next_level)
                 .with_system(gameplay::transitions::level_card_update)
-                .with_system(gameplay::transitions::fit_camera_around_play_zone_padded)
                 .with_system(gameplay::transitions::spawn_goal_ghosts)
                 .into(),
         )

--- a/src/sugar.rs
+++ b/src/sugar.rs
@@ -167,13 +167,13 @@ pub fn history_sugar(
     mut history_commands: EventReader<HistoryCommands>,
     mut player_query: Query<&mut PlayerAnimationState>,
     audio: Res<Audio>,
-    sfx: Res<SoundEffects>,
+    sfx: Res<AssetHolder>,
 ) {
     for command in history_commands.iter() {
         match command {
             HistoryCommands::Rewind | HistoryCommands::Reset => {
                 *player_query.single_mut() = PlayerAnimationState::Idle(Direction::Down);
-                audio.play(sfx.undo.clone_weak());
+                audio.play(sfx.undo_sound.clone_weak());
             }
             _ => (),
         }


### PR DESCRIPTION
Closes #3 
Closes #15

This PR introduces `GameState`, which is replacing `LevelState`. This `GameState` is an actual bevy state, and it separates gameplay systems from level-transition systems. It also provides a barrier at the start of the game between asset loading and the first level transition.

`GameState` is then used to refactor some things. In particular, instead of manually checking the game state within systems that should only be run in a particular state, that "check" is implicitly performed by using run criteria on those systems in the schedule. Those systems won't even run unless that state is active now.

These scheduling changes are assisted by two new dependencies: `iyes_loopless` for providing very ergonomic run conditions, and `bevy_asset_loader` for simplifying the asset loading state transition.

Furthermore, now the `LdtkWorldBundle` isn't even spawned until the first level card is all the way up. This makes things look a little less janky in general, but most importantly it seems to completely fix the game breaking bug on WASM.

I still want to play around with the schedule some more, add more run criteria here and there, simplify systems a bit.. but I think this is a solid unit of work worth merging, especially since a major bug has been fixed.