### PR TITLE
refactor: add willo and sokoban modules and move relevant items to them

### DIFF
--- a/src/bundles.rs
+++ b/src/bundles.rs
@@ -1,4 +1,8 @@
-use crate::{gameplay::components::*, history::History, willo::PlayerAnimationState};
+use crate::{
+    gameplay::components::*,
+    history::History,
+    willo::{PlayerAnimationState, PlayerState},
+};
 use bevy::prelude::*;
 use bevy_ecs_ldtk::prelude::*;
 

--- a/src/bundles.rs
+++ b/src/bundles.rs
@@ -1,8 +1,4 @@
-use crate::{
-    gameplay::components::*,
-    history::History,
-    willo::{PlayerAnimationState, PlayerState},
-};
+use crate::{gameplay::components::*, history::History, sokoban::RigidBody};
 use bevy::prelude::*;
 use bevy_ecs_ldtk::prelude::*;
 
@@ -34,21 +30,6 @@ pub struct GoalBundle {
     #[sprite_sheet_bundle]
     #[bundle]
     pub sprite_sheet_bundle: SpriteSheetBundle,
-}
-
-#[derive(Clone, Bundle, LdtkEntity)]
-pub struct PlayerBundle {
-    #[grid_coords]
-    pub grid_coords: GridCoords,
-    pub history: History<GridCoords>,
-    #[from_entity_instance]
-    pub rigid_body: RigidBody,
-    pub player_state: PlayerState,
-    pub movement_timer: MovementTimer,
-    #[sprite_sheet_bundle]
-    #[bundle]
-    pub sprite_sheet_bundle: SpriteSheetBundle,
-    pub player_animation_state: PlayerAnimationState,
 }
 
 #[derive(Clone, Bundle, LdtkEntity)]

--- a/src/bundles.rs
+++ b/src/bundles.rs
@@ -1,4 +1,4 @@
-use crate::{gameplay::components::*, history::History, sugar::*};
+use crate::{gameplay::components::*, history::History, willo::PlayerAnimationState};
 use bevy::prelude::*;
 use bevy_ecs_ldtk::prelude::*;
 

--- a/src/bundles.rs
+++ b/src/bundles.rs
@@ -2,12 +2,6 @@ use crate::{gameplay::components::*, history::History, sokoban::RigidBody};
 use bevy::prelude::*;
 use bevy_ecs_ldtk::prelude::*;
 
-#[derive(Clone, Bundle, LdtkIntCell)]
-pub struct WallBundle {
-    #[from_int_grid_cell]
-    rigid_body: RigidBody,
-}
-
 #[derive(Clone, Bundle, LdtkEntity)]
 pub struct InputBlockBundle {
     #[grid_coords]

--- a/src/gameplay/components.rs
+++ b/src/gameplay/components.rs
@@ -51,20 +51,6 @@ pub struct MoveTable {
 }
 
 #[derive(Copy, Clone, Eq, PartialEq, Debug, Hash, Component)]
-pub enum PlayerState {
-    Waiting,
-    Dead,
-    RankMove(KeyCode),
-    FileMove(KeyCode),
-}
-
-impl Default for PlayerState {
-    fn default() -> PlayerState {
-        PlayerState::Waiting
-    }
-}
-
-#[derive(Copy, Clone, Eq, PartialEq, Debug, Hash, Component)]
 pub enum LevelCard {
     Rising,
     Holding,

--- a/src/gameplay/components.rs
+++ b/src/gameplay/components.rs
@@ -2,24 +2,6 @@ use bevy::prelude::*;
 use bevy_ecs_ldtk::prelude::*;
 
 #[derive(Copy, Clone, Eq, PartialEq, Debug, Hash, Component)]
-pub enum RigidBody {
-    Static,
-    Dynamic,
-}
-
-impl From<EntityInstance> for RigidBody {
-    fn from(_: EntityInstance) -> RigidBody {
-        RigidBody::Dynamic
-    }
-}
-
-impl From<IntGridCell> for RigidBody {
-    fn from(_: IntGridCell) -> RigidBody {
-        RigidBody::Static
-    }
-}
-
-#[derive(Copy, Clone, Eq, PartialEq, Debug, Hash, Component)]
 pub struct InputBlock {
     pub key_code: KeyCode,
 }
@@ -60,17 +42,6 @@ pub enum LevelCard {
 
 #[derive(Copy, Clone, Eq, PartialEq, Debug, Default, Hash, Component)]
 pub struct DeathCard;
-
-const MOVEMENT_SECONDS: f32 = 0.14;
-
-#[derive(Clone, Debug, Component)]
-pub struct MovementTimer(pub Timer);
-
-impl Default for MovementTimer {
-    fn default() -> MovementTimer {
-        MovementTimer(Timer::from_seconds(MOVEMENT_SECONDS, false))
-    }
-}
 
 #[derive(Copy, Clone, Eq, PartialEq, Debug, Default, Component)]
 pub struct OrthographicCamera;

--- a/src/gameplay/mod.rs
+++ b/src/gameplay/mod.rs
@@ -37,7 +37,7 @@ impl From<Direction> for IVec2 {
 
 #[derive(Copy, Clone, Eq, PartialEq, Debug, Hash)]
 pub struct DeathEvent {
-    pub player_entity: Entity,
+    pub willo_entity: Entity,
 }
 
 #[derive(Clone, Eq, PartialEq, Debug)]

--- a/src/gameplay/mod.rs
+++ b/src/gameplay/mod.rs
@@ -36,11 +36,6 @@ impl From<Direction> for IVec2 {
 }
 
 #[derive(Copy, Clone, Eq, PartialEq, Debug, Hash)]
-pub struct PlayerMovementEvent {
-    direction: Direction,
-}
-
-#[derive(Copy, Clone, Eq, PartialEq, Debug, Hash)]
 pub struct DeathEvent {
     pub player_entity: Entity,
 }

--- a/src/gameplay/systems.rs
+++ b/src/gameplay/systems.rs
@@ -3,129 +3,13 @@ use crate::{
     gameplay::{components::*, DeathEvent, Direction, GoalEvent, LevelCardEvent, DIRECTION_ORDER},
     history::HistoryCommands,
     resources::*,
-    willo::{PlayerAnimationState, PlayerMovementEvent, PlayerState},
+    willo::{PlayerMovementEvent, PlayerState},
     AssetHolder, GameState,
 };
 use bevy::prelude::*;
 use bevy_ecs_ldtk::prelude::*;
 use iyes_loopless::prelude::*;
 use std::time::Duration;
-
-fn push_grid_coords_recursively(
-    collision_map: Vec<Vec<Option<(Entity, RigidBody)>>>,
-    pusher_coords: IVec2,
-    direction: Direction,
-) -> Vec<Entity> {
-    let pusher = collision_map[pusher_coords.y as usize][pusher_coords.x as usize]
-        .expect("pusher should exist")
-        .0;
-    let destination = pusher_coords + IVec2::from(direction);
-    if destination.x < 0
-        || destination.y < 0
-        || destination.y as usize >= collision_map.len()
-        || destination.x as usize >= collision_map[0].len()
-    {
-        return Vec::new();
-    }
-    match collision_map[destination.y as usize][destination.x as usize] {
-        None => vec![pusher],
-        Some((_, RigidBody::Static)) => Vec::new(),
-        Some((_, RigidBody::Dynamic)) => {
-            let mut pushed_entities =
-                push_grid_coords_recursively(collision_map, destination, direction);
-            if pushed_entities.is_empty() {
-                Vec::new()
-            } else {
-                pushed_entities.push(pusher);
-                pushed_entities
-            }
-        }
-    }
-}
-
-pub fn perform_grid_coords_movement(
-    mut grid_coords_query: Query<(
-        Entity,
-        &mut GridCoords,
-        &RigidBody,
-        Option<&mut PlayerAnimationState>,
-    )>,
-    mut reader: EventReader<PlayerMovementEvent>,
-    level_query: Query<&Handle<LdtkLevel>>,
-    levels: Res<Assets<LdtkLevel>>,
-    audio: Res<Audio>,
-    sfx: Res<AssetHolder>,
-) {
-    for movement_event in reader.iter() {
-        let level = levels
-            .get(level_query.single())
-            .expect("Level should be loaded in gameplay state");
-
-        let LayerInstance {
-            c_wid: width,
-            c_hei: height,
-            ..
-        } = level
-            .level
-            .layer_instances
-            .clone()
-            .expect("Loaded level should have layers")[0];
-
-        let mut collision_map: Vec<Vec<Option<(Entity, RigidBody)>>> =
-            vec![vec![None; width as usize]; height as usize];
-
-        for (entity, grid_coords, rigid_body, _) in grid_coords_query.iter_mut() {
-            collision_map[grid_coords.y as usize][grid_coords.x as usize] =
-                Some((entity, *rigid_body));
-        }
-
-        if let Some((_, player_grid_coords, _, Some(mut animation))) = grid_coords_query
-            .iter_mut()
-            .find(|(_, _, _, animation)| animation.is_some())
-        {
-            let pushed_entities = push_grid_coords_recursively(
-                collision_map,
-                IVec2::from(*player_grid_coords),
-                movement_event.direction,
-            );
-
-            if pushed_entities.len() > 1 {
-                audio.play(sfx.push_sound.clone_weak());
-                *animation.into_inner() = PlayerAnimationState::Push(movement_event.direction);
-            } else {
-                let new_state = PlayerAnimationState::Idle(movement_event.direction);
-                if *animation != new_state {
-                    *animation = new_state;
-                }
-            }
-
-            for entity in pushed_entities {
-                *grid_coords_query
-                    .get_component_mut::<GridCoords>(entity)
-                    .expect("Pushed should have GridCoords component") +=
-                    GridCoords::from(IVec2::from(movement_event.direction));
-            }
-        }
-    }
-}
-
-pub fn move_table_update(
-    mut table_query: Query<(&GridCoords, &mut MoveTable)>,
-    input_block_query: Query<(&GridCoords, &InputBlock)>,
-) {
-    for (table_grid_coords, mut table) in table_query.iter_mut() {
-        table.table = [[None; 4]; 4];
-        for (input_grid_coords, input_block) in input_block_query.iter() {
-            let diff = *input_grid_coords - *table_grid_coords;
-            let x_index = diff.x - 1;
-            let y_index = -1 - diff.y;
-            if (0..4).contains(&x_index) && (0..4).contains(&y_index) {
-                // key block is in table
-                table.table[y_index as usize][x_index as usize] = Some(input_block.key_code);
-            }
-        }
-    }
-}
 
 pub fn player_state_input(
     mut player_query: Query<&mut PlayerState>,

--- a/src/gameplay/systems.rs
+++ b/src/gameplay/systems.rs
@@ -1,7 +1,7 @@
 use crate::{
     event_scheduler::EventScheduler,
     gameplay::{components::*, DeathEvent, Direction, GoalEvent, LevelCardEvent, DIRECTION_ORDER},
-    willo::PlayerState,
+    willo::WilloState,
     AssetHolder, GameState,
 };
 use bevy::prelude::*;
@@ -10,17 +10,15 @@ use iyes_loopless::prelude::*;
 use std::time::Duration;
 
 pub fn check_death(
-    mut player_query: Query<(Entity, &GridCoords, &mut PlayerState)>,
+    mut willo_query: Query<(Entity, &GridCoords, &mut WilloState)>,
     exorcism_query: Query<(Entity, &GridCoords), With<ExorcismBlock>>,
     mut death_event_writer: EventWriter<DeathEvent>,
 ) {
-    if let Ok((entity, player_coords, mut player_state)) = player_query.get_single_mut() {
-        if *player_state != PlayerState::Dead
-            && exorcism_query.iter().any(|(_, g)| *g == *player_coords)
-        {
-            *player_state = PlayerState::Dead;
+    if let Ok((entity, coords, mut willo)) = willo_query.get_single_mut() {
+        if *willo != WilloState::Dead && exorcism_query.iter().any(|(_, g)| *g == *coords) {
+            *willo = WilloState::Dead;
             death_event_writer.send(DeathEvent {
-                player_entity: entity,
+                willo_entity: entity,
             });
         }
     }

--- a/src/gameplay/systems.rs
+++ b/src/gameplay/systems.rs
@@ -6,7 +6,7 @@ use crate::{
     },
     history::HistoryCommands,
     resources::*,
-    sugar::PlayerAnimationState,
+    willo::PlayerAnimationState,
     AssetHolder, GameState,
 };
 use bevy::prelude::*;

--- a/src/gameplay/systems.rs
+++ b/src/gameplay/systems.rs
@@ -3,7 +3,7 @@ use crate::{
     gameplay::{components::*, DeathEvent, Direction, GoalEvent, LevelCardEvent, DIRECTION_ORDER},
     history::HistoryCommands,
     resources::*,
-    willo::{PlayerMovementEvent, PlayerState},
+    willo::PlayerState,
     AssetHolder, GameState,
 };
 use bevy::prelude::*;
@@ -61,49 +61,6 @@ pub fn player_state_input(
             } else if input.just_pressed(KeyCode::R) {
                 history_commands.send(HistoryCommands::Reset);
                 *player = PlayerState::Waiting;
-            }
-        }
-    }
-}
-
-pub fn move_player_by_table(
-    table_query: Query<&MoveTable>,
-    mut player_query: Query<(&mut MovementTimer, &mut PlayerState)>,
-    mut movement_writer: EventWriter<PlayerMovementEvent>,
-    time: Res<Time>,
-) {
-    for table in table_query.iter() {
-        if let Ok((mut timer, mut player)) = player_query.get_single_mut() {
-            timer.0.tick(time.delta());
-
-            if timer.0.finished() {
-                match *player {
-                    PlayerState::RankMove(key) => {
-                        for (i, rank) in table.table.iter().enumerate() {
-                            if rank.contains(&Some(key)) {
-                                movement_writer.send(PlayerMovementEvent {
-                                    direction: DIRECTION_ORDER[i],
-                                });
-                            }
-                        }
-                        *player = PlayerState::FileMove(key);
-                        timer.0.reset();
-                    }
-                    PlayerState::FileMove(key) => {
-                        for rank in table.table.iter() {
-                            for (i, cell) in rank.iter().enumerate() {
-                                if *cell == Some(key) {
-                                    movement_writer.send(PlayerMovementEvent {
-                                        direction: DIRECTION_ORDER[i],
-                                    });
-                                }
-                            }
-                        }
-                        *player = PlayerState::Waiting;
-                        timer.0.reset();
-                    }
-                    _ => {}
-                }
             }
         }
     }

--- a/src/gameplay/systems.rs
+++ b/src/gameplay/systems.rs
@@ -1,12 +1,9 @@
 use crate::{
     event_scheduler::EventScheduler,
-    gameplay::{
-        components::*, DeathEvent, Direction, GoalEvent, LevelCardEvent, PlayerMovementEvent,
-        DIRECTION_ORDER,
-    },
+    gameplay::{components::*, DeathEvent, Direction, GoalEvent, LevelCardEvent, DIRECTION_ORDER},
     history::HistoryCommands,
     resources::*,
-    willo::PlayerAnimationState,
+    willo::{PlayerAnimationState, PlayerMovementEvent, PlayerState},
     AssetHolder, GameState,
 };
 use bevy::prelude::*;

--- a/src/gameplay/transitions.rs
+++ b/src/gameplay/transitions.rs
@@ -4,7 +4,7 @@ use crate::{
     nine_slice::*,
     resources::*,
     sugar::GoalGhostAnimation,
-    willo::PlayerState,
+    willo::WilloState,
     AssetHolder, GameState,
 };
 use bevy::prelude::*;
@@ -149,13 +149,13 @@ pub fn spawn_control_display(
 pub fn spawn_death_card(
     mut commands: Commands,
     assets: Res<AssetServer>,
-    player_query: Query<&PlayerState, Changed<PlayerState>>,
+    willo_query: Query<&WilloState, Changed<WilloState>>,
     death_cards: Query<Entity, With<DeathCard>>,
-    mut last_state: Local<PlayerState>,
+    mut last_state: Local<WilloState>,
     ui_root_query: Query<Entity, With<UiRoot>>,
 ) {
-    for state in player_query.iter() {
-        if *state == PlayerState::Dead && *last_state != PlayerState::Dead {
+    for state in willo_query.iter() {
+        if *state == WilloState::Dead && *last_state != WilloState::Dead {
             // Player just died
             let death_card_entity = commands
                 .spawn_bundle(NodeBundle {
@@ -227,7 +227,7 @@ pub fn spawn_death_card(
             commands
                 .entity(ui_root_query.single())
                 .add_child(death_card_entity);
-        } else if *state != PlayerState::Dead && *last_state == PlayerState::Dead {
+        } else if *state != WilloState::Dead && *last_state == WilloState::Dead {
             // Player just un-died
             if let Ok(entity) = death_cards.get_single() {
                 commands.entity(entity).despawn_recursive();

--- a/src/gameplay/transitions.rs
+++ b/src/gameplay/transitions.rs
@@ -4,6 +4,7 @@ use crate::{
     nine_slice::*,
     resources::*,
     sugar::GoalGhostAnimation,
+    willo::PlayerState,
     AssetHolder, GameState,
 };
 use bevy::prelude::*;

--- a/src/main.rs
+++ b/src/main.rs
@@ -65,7 +65,6 @@ fn main() {
         .add_plugin(EasingsPlugin)
         .add_plugin(LdtkPlugin)
         .add_plugin(SpriteSheetAnimationPlugin)
-        .add_plugin(FromComponentAnimator::<willo::WilloAnimationState>::new())
         .add_event::<animation::AnimationEvent>()
         .add_loopless_state(GameState::AssetLoading)
         .add_loading_state(
@@ -75,7 +74,7 @@ fn main() {
         )
         .add_plugin(ui::UiPlugin)
         .add_plugin(level_select::LevelSelectPlugin)
-        .add_event::<willo::WilloMovementEvent>()
+        .add_plugin(willo::WilloPlugin)
         .add_event::<history::HistoryCommands>()
         .add_event::<gameplay::DeathEvent>()
         .add_event::<gameplay::GoalEvent>()
@@ -121,12 +120,6 @@ fn main() {
                 .before(SystemLabels::Input),
         )
         .add_system(
-            willo::willo_input
-                .run_in_state(GameState::Gameplay)
-                .label(SystemLabels::Input)
-                .before(history::FlushHistoryCommands),
-        )
-        .add_system(
             sokoban::perform_grid_coords_movement
                 .run_in_state(GameState::Gameplay)
                 .label(SystemLabels::MoveTableUpdate)
@@ -148,22 +141,8 @@ fn main() {
                 .run_in_state(GameState::Gameplay)
                 .after(SystemLabels::CheckDeath),
         )
-        .add_system(
-            willo::move_willo_by_table
-                .run_in_state(GameState::Gameplay)
-                .after(SystemLabels::MoveTableUpdate)
-                .after(history::FlushHistoryCommands),
-        )
         .add_system(gameplay::transitions::spawn_death_card.run_in_state(GameState::Gameplay))
         .add_system(gameplay::systems::update_control_display.run_in_state(GameState::Gameplay))
-        // Systems with potential easing end/beginning collisions cannot be in CoreStage::Update
-        // see https://github.com/vleue/bevy_easings/issues/23
-        .add_system_to_stage(
-            CoreStage::PostUpdate,
-            willo::reset_willo_easing
-                .run_not_in_state(GameState::AssetLoading)
-                .before("ease_movement"),
-        )
         .add_system_to_stage(
             CoreStage::PostUpdate,
             sokoban::ease_movement
@@ -173,9 +152,6 @@ fn main() {
         .add_system(sugar::goal_ghost_animation.run_not_in_state(GameState::AssetLoading))
         .add_system(sugar::goal_ghost_event_sugar.run_not_in_state(GameState::AssetLoading))
         .add_system(sugar::animate_grass_system.run_not_in_state(GameState::AssetLoading))
-        .add_system(willo::play_death_animations.run_not_in_state(GameState::AssetLoading))
-        .add_system(willo::history_sugar.run_not_in_state(GameState::AssetLoading))
-        .register_ldtk_entity::<willo::WilloBundle>("Willo")
         .register_ldtk_entity::<bundles::InputBlockBundle>("W")
         .register_ldtk_entity::<bundles::InputBlockBundle>("A")
         .register_ldtk_entity::<bundles::InputBlockBundle>("S")

--- a/src/main.rs
+++ b/src/main.rs
@@ -74,7 +74,7 @@ fn main() {
         )
         .add_plugin(ui::UiPlugin)
         .add_plugin(level_select::LevelSelectPlugin)
-        .add_event::<gameplay::PlayerMovementEvent>()
+        .add_event::<willo::PlayerMovementEvent>()
         .add_event::<history::HistoryCommands>()
         .add_event::<gameplay::DeathEvent>()
         .add_event::<gameplay::GoalEvent>()

--- a/src/main.rs
+++ b/src/main.rs
@@ -13,6 +13,7 @@ mod previous_component;
 mod resources;
 mod sugar;
 mod ui;
+mod willo;
 
 use animation::{FromComponentAnimator, SpriteSheetAnimationPlugin};
 use bevy::{prelude::*, render::texture::ImageSettings};
@@ -63,7 +64,7 @@ fn main() {
         .add_plugin(EasingsPlugin)
         .add_plugin(LdtkPlugin)
         .add_plugin(SpriteSheetAnimationPlugin)
-        .add_plugin(FromComponentAnimator::<sugar::PlayerAnimationState>::new())
+        .add_plugin(FromComponentAnimator::<willo::PlayerAnimationState>::new())
         .add_event::<animation::AnimationEvent>()
         .add_loopless_state(GameState::AssetLoading)
         .add_loading_state(
@@ -158,21 +159,21 @@ fn main() {
         // see https://github.com/vleue/bevy_easings/issues/23
         .add_system_to_stage(
             CoreStage::PostUpdate,
-            sugar::reset_player_easing
+            willo::reset_player_easing
                 .run_not_in_state(GameState::AssetLoading)
                 .before("ease_movement"),
         )
         .add_system_to_stage(
             CoreStage::PostUpdate,
-            sugar::ease_movement
+            willo::ease_movement
                 .run_not_in_state(GameState::AssetLoading)
                 .label("ease_movement"),
         )
         .add_system(sugar::goal_ghost_animation.run_not_in_state(GameState::AssetLoading))
         .add_system(sugar::goal_ghost_event_sugar.run_not_in_state(GameState::AssetLoading))
         .add_system(sugar::animate_grass_system.run_not_in_state(GameState::AssetLoading))
-        .add_system(sugar::play_death_animations.run_not_in_state(GameState::AssetLoading))
-        .add_system(sugar::history_sugar.run_not_in_state(GameState::AssetLoading))
+        .add_system(willo::play_death_animations.run_not_in_state(GameState::AssetLoading))
+        .add_system(willo::history_sugar.run_not_in_state(GameState::AssetLoading))
         .register_ldtk_entity::<bundles::PlayerBundle>("Willo")
         .register_ldtk_entity::<bundles::InputBlockBundle>("W")
         .register_ldtk_entity::<bundles::InputBlockBundle>("A")

--- a/src/main.rs
+++ b/src/main.rs
@@ -121,7 +121,7 @@ fn main() {
                 .before(SystemLabels::Input),
         )
         .add_system(
-            gameplay::systems::player_state_input
+            willo::player_state_input
                 .run_in_state(GameState::Gameplay)
                 .label(SystemLabels::Input)
                 .before(history::FlushHistoryCommands),

--- a/src/main.rs
+++ b/src/main.rs
@@ -11,6 +11,7 @@ mod level_select;
 mod nine_slice;
 mod previous_component;
 mod resources;
+mod sokoban;
 mod sugar;
 mod ui;
 mod willo;
@@ -115,7 +116,7 @@ fn main() {
                 .into(),
         )
         .add_system(
-            gameplay::systems::move_table_update
+            sokoban::move_table_update
                 .run_in_state(GameState::Gameplay)
                 .before(SystemLabels::Input),
         )
@@ -126,7 +127,7 @@ fn main() {
                 .before(history::FlushHistoryCommands),
         )
         .add_system(
-            gameplay::systems::perform_grid_coords_movement
+            sokoban::perform_grid_coords_movement
                 .run_in_state(GameState::Gameplay)
                 .label(SystemLabels::MoveTableUpdate)
                 .before(from_component::FromComponentLabel),
@@ -165,7 +166,7 @@ fn main() {
         )
         .add_system_to_stage(
             CoreStage::PostUpdate,
-            willo::ease_movement
+            sokoban::ease_movement
                 .run_not_in_state(GameState::AssetLoading)
                 .label("ease_movement"),
         )

--- a/src/main.rs
+++ b/src/main.rs
@@ -183,9 +183,9 @@ fn main() {
         .register_ldtk_entity::<bundles::GoalBundle>("Goal")
         .register_ldtk_entity::<bundles::MoveTableBundle>("Table")
         .register_ldtk_entity::<bundles::GrassBundle>("Grass")
-        .register_ldtk_int_cell::<bundles::WallBundle>(1)
-        .register_ldtk_int_cell::<bundles::WallBundle>(3)
-        .register_ldtk_int_cell::<bundles::WallBundle>(4)
+        .register_ldtk_int_cell::<sokoban::WallBundle>(1)
+        .register_ldtk_int_cell::<sokoban::WallBundle>(3)
+        .register_ldtk_int_cell::<sokoban::WallBundle>(4)
         .register_ldtk_int_cell::<bundles::ExorcismBlockBundle>(2)
         .register_ldtk_int_cell::<bundles::ExorcismBlockBundle>(2);
 

--- a/src/main.rs
+++ b/src/main.rs
@@ -175,7 +175,7 @@ fn main() {
         .add_system(sugar::animate_grass_system.run_not_in_state(GameState::AssetLoading))
         .add_system(willo::play_death_animations.run_not_in_state(GameState::AssetLoading))
         .add_system(willo::history_sugar.run_not_in_state(GameState::AssetLoading))
-        .register_ldtk_entity::<bundles::PlayerBundle>("Willo")
+        .register_ldtk_entity::<willo::PlayerBundle>("Willo")
         .register_ldtk_entity::<bundles::InputBlockBundle>("W")
         .register_ldtk_entity::<bundles::InputBlockBundle>("A")
         .register_ldtk_entity::<bundles::InputBlockBundle>("S")

--- a/src/main.rs
+++ b/src/main.rs
@@ -149,7 +149,7 @@ fn main() {
                 .after(SystemLabels::CheckDeath),
         )
         .add_system(
-            gameplay::systems::move_player_by_table
+            willo::move_player_by_table
                 .run_in_state(GameState::Gameplay)
                 .after(SystemLabels::MoveTableUpdate)
                 .after(history::FlushHistoryCommands),

--- a/src/main.rs
+++ b/src/main.rs
@@ -75,6 +75,7 @@ fn main() {
         .add_plugin(ui::UiPlugin)
         .add_plugin(level_select::LevelSelectPlugin)
         .add_plugin(willo::WilloPlugin)
+        .add_plugin(sokoban::SokobanPlugin)
         .add_event::<history::HistoryCommands>()
         .add_event::<gameplay::DeathEvent>()
         .add_event::<gameplay::GoalEvent>()
@@ -115,17 +116,6 @@ fn main() {
                 .into(),
         )
         .add_system(
-            sokoban::move_table_update
-                .run_in_state(GameState::Gameplay)
-                .before(SystemLabels::Input),
-        )
-        .add_system(
-            sokoban::perform_grid_coords_movement
-                .run_in_state(GameState::Gameplay)
-                .label(SystemLabels::MoveTableUpdate)
-                .before(from_component::FromComponentLabel),
-        )
-        .add_system(
             gameplay::systems::check_death
                 .run_in_state(GameState::Gameplay)
                 .label(SystemLabels::CheckDeath)
@@ -143,12 +133,6 @@ fn main() {
         )
         .add_system(gameplay::transitions::spawn_death_card.run_in_state(GameState::Gameplay))
         .add_system(gameplay::systems::update_control_display.run_in_state(GameState::Gameplay))
-        .add_system_to_stage(
-            CoreStage::PostUpdate,
-            sokoban::ease_movement
-                .run_not_in_state(GameState::AssetLoading)
-                .label("ease_movement"),
-        )
         .add_system(sugar::goal_ghost_animation.run_not_in_state(GameState::AssetLoading))
         .add_system(sugar::goal_ghost_event_sugar.run_not_in_state(GameState::AssetLoading))
         .add_system(sugar::animate_grass_system.run_not_in_state(GameState::AssetLoading))
@@ -159,9 +143,6 @@ fn main() {
         .register_ldtk_entity::<bundles::GoalBundle>("Goal")
         .register_ldtk_entity::<bundles::MoveTableBundle>("Table")
         .register_ldtk_entity::<bundles::GrassBundle>("Grass")
-        .register_ldtk_int_cell::<sokoban::WallBundle>(1)
-        .register_ldtk_int_cell::<sokoban::WallBundle>(3)
-        .register_ldtk_int_cell::<sokoban::WallBundle>(4)
         .register_ldtk_int_cell::<bundles::ExorcismBlockBundle>(2)
         .register_ldtk_int_cell::<bundles::ExorcismBlockBundle>(2);
 

--- a/src/main.rs
+++ b/src/main.rs
@@ -65,7 +65,7 @@ fn main() {
         .add_plugin(EasingsPlugin)
         .add_plugin(LdtkPlugin)
         .add_plugin(SpriteSheetAnimationPlugin)
-        .add_plugin(FromComponentAnimator::<willo::PlayerAnimationState>::new())
+        .add_plugin(FromComponentAnimator::<willo::WilloAnimationState>::new())
         .add_event::<animation::AnimationEvent>()
         .add_loopless_state(GameState::AssetLoading)
         .add_loading_state(
@@ -75,7 +75,7 @@ fn main() {
         )
         .add_plugin(ui::UiPlugin)
         .add_plugin(level_select::LevelSelectPlugin)
-        .add_event::<willo::PlayerMovementEvent>()
+        .add_event::<willo::WilloMovementEvent>()
         .add_event::<history::HistoryCommands>()
         .add_event::<gameplay::DeathEvent>()
         .add_event::<gameplay::GoalEvent>()
@@ -121,7 +121,7 @@ fn main() {
                 .before(SystemLabels::Input),
         )
         .add_system(
-            willo::player_state_input
+            willo::willo_input
                 .run_in_state(GameState::Gameplay)
                 .label(SystemLabels::Input)
                 .before(history::FlushHistoryCommands),
@@ -149,7 +149,7 @@ fn main() {
                 .after(SystemLabels::CheckDeath),
         )
         .add_system(
-            willo::move_player_by_table
+            willo::move_willo_by_table
                 .run_in_state(GameState::Gameplay)
                 .after(SystemLabels::MoveTableUpdate)
                 .after(history::FlushHistoryCommands),
@@ -160,7 +160,7 @@ fn main() {
         // see https://github.com/vleue/bevy_easings/issues/23
         .add_system_to_stage(
             CoreStage::PostUpdate,
-            willo::reset_player_easing
+            willo::reset_willo_easing
                 .run_not_in_state(GameState::AssetLoading)
                 .before("ease_movement"),
         )
@@ -175,7 +175,7 @@ fn main() {
         .add_system(sugar::animate_grass_system.run_not_in_state(GameState::AssetLoading))
         .add_system(willo::play_death_animations.run_not_in_state(GameState::AssetLoading))
         .add_system(willo::history_sugar.run_not_in_state(GameState::AssetLoading))
-        .register_ldtk_entity::<willo::PlayerBundle>("Willo")
+        .register_ldtk_entity::<willo::WilloBundle>("Willo")
         .register_ldtk_entity::<bundles::InputBlockBundle>("W")
         .register_ldtk_entity::<bundles::InputBlockBundle>("A")
         .register_ldtk_entity::<bundles::InputBlockBundle>("S")

--- a/src/sokoban.rs
+++ b/src/sokoban.rs
@@ -1,0 +1,153 @@
+use crate::gameplay::Direction;
+use crate::{
+    gameplay::{components::*, xy_translation},
+    willo::{PlayerAnimationState, PlayerMovementEvent},
+    *,
+};
+use bevy::prelude::*;
+use bevy_easings::*;
+
+pub fn ease_movement(
+    mut commands: Commands,
+    mut grid_coords_query: Query<
+        (
+            Entity,
+            &GridCoords,
+            &Transform,
+            Option<&PlayerAnimationState>,
+        ),
+        (Changed<GridCoords>, Without<MoveTable>),
+    >,
+) {
+    for (entity, &grid_coords, transform, player_state) in grid_coords_query.iter_mut() {
+        let mut xy = xy_translation(grid_coords.into());
+
+        if let Some(PlayerAnimationState::Push(direction)) = player_state {
+            xy += IVec2::from(*direction).as_vec2() * 5.;
+        }
+
+        commands.entity(entity).insert(transform.ease_to(
+            Transform::from_xyz(xy.x, xy.y, transform.translation.z),
+            EaseFunction::CubicOut,
+            EasingType::Once {
+                duration: std::time::Duration::from_millis(110),
+            },
+        ));
+    }
+}
+
+fn push_grid_coords_recursively(
+    collision_map: Vec<Vec<Option<(Entity, RigidBody)>>>,
+    pusher_coords: IVec2,
+    direction: Direction,
+) -> Vec<Entity> {
+    let pusher = collision_map[pusher_coords.y as usize][pusher_coords.x as usize]
+        .expect("pusher should exist")
+        .0;
+    let destination = pusher_coords + IVec2::from(direction);
+    if destination.x < 0
+        || destination.y < 0
+        || destination.y as usize >= collision_map.len()
+        || destination.x as usize >= collision_map[0].len()
+    {
+        return Vec::new();
+    }
+    match collision_map[destination.y as usize][destination.x as usize] {
+        None => vec![pusher],
+        Some((_, RigidBody::Static)) => Vec::new(),
+        Some((_, RigidBody::Dynamic)) => {
+            let mut pushed_entities =
+                push_grid_coords_recursively(collision_map, destination, direction);
+            if pushed_entities.is_empty() {
+                Vec::new()
+            } else {
+                pushed_entities.push(pusher);
+                pushed_entities
+            }
+        }
+    }
+}
+
+pub fn perform_grid_coords_movement(
+    mut grid_coords_query: Query<(
+        Entity,
+        &mut GridCoords,
+        &RigidBody,
+        Option<&mut PlayerAnimationState>,
+    )>,
+    mut reader: EventReader<PlayerMovementEvent>,
+    level_query: Query<&Handle<LdtkLevel>>,
+    levels: Res<Assets<LdtkLevel>>,
+    audio: Res<Audio>,
+    sfx: Res<AssetHolder>,
+) {
+    for movement_event in reader.iter() {
+        let level = levels
+            .get(level_query.single())
+            .expect("Level should be loaded in gameplay state");
+
+        let LayerInstance {
+            c_wid: width,
+            c_hei: height,
+            ..
+        } = level
+            .level
+            .layer_instances
+            .clone()
+            .expect("Loaded level should have layers")[0];
+
+        let mut collision_map: Vec<Vec<Option<(Entity, RigidBody)>>> =
+            vec![vec![None; width as usize]; height as usize];
+
+        for (entity, grid_coords, rigid_body, _) in grid_coords_query.iter_mut() {
+            collision_map[grid_coords.y as usize][grid_coords.x as usize] =
+                Some((entity, *rigid_body));
+        }
+
+        if let Some((_, player_grid_coords, _, Some(mut animation))) = grid_coords_query
+            .iter_mut()
+            .find(|(_, _, _, animation)| animation.is_some())
+        {
+            let pushed_entities = push_grid_coords_recursively(
+                collision_map,
+                IVec2::from(*player_grid_coords),
+                movement_event.direction,
+            );
+
+            if pushed_entities.len() > 1 {
+                audio.play(sfx.push_sound.clone_weak());
+                *animation.into_inner() = PlayerAnimationState::Push(movement_event.direction);
+            } else {
+                let new_state = PlayerAnimationState::Idle(movement_event.direction);
+                if *animation != new_state {
+                    *animation = new_state;
+                }
+            }
+
+            for entity in pushed_entities {
+                *grid_coords_query
+                    .get_component_mut::<GridCoords>(entity)
+                    .expect("Pushed should have GridCoords component") +=
+                    GridCoords::from(IVec2::from(movement_event.direction));
+            }
+        }
+    }
+}
+
+pub fn move_table_update(
+    mut table_query: Query<(&GridCoords, &mut MoveTable)>,
+    input_block_query: Query<(&GridCoords, &InputBlock)>,
+) {
+    for (table_grid_coords, mut table) in table_query.iter_mut() {
+        table.table = [[None; 4]; 4];
+        for (input_grid_coords, input_block) in input_block_query.iter() {
+            let diff = *input_grid_coords - *table_grid_coords;
+            let x_index = diff.x - 1;
+            let y_index = -1 - diff.y;
+            if (0..4).contains(&x_index) && (0..4).contains(&y_index) {
+                // key block is in table
+                table.table[y_index as usize][x_index as usize] = Some(input_block.key_code);
+            }
+        }
+    }
+}

--- a/src/sokoban.rs
+++ b/src/sokoban.rs
@@ -13,6 +13,12 @@ pub enum RigidBody {
     Dynamic,
 }
 
+#[derive(Clone, Bundle, LdtkIntCell)]
+pub struct WallBundle {
+    #[from_int_grid_cell]
+    rigid_body: RigidBody,
+}
+
 impl From<EntityInstance> for RigidBody {
     fn from(_: EntityInstance) -> RigidBody {
         RigidBody::Dynamic

--- a/src/sokoban.rs
+++ b/src/sokoban.rs
@@ -43,7 +43,7 @@ pub enum RigidBody {
 }
 
 #[derive(Clone, Bundle, LdtkIntCell)]
-pub struct WallBundle {
+struct WallBundle {
     #[from_int_grid_cell]
     rigid_body: RigidBody,
 }
@@ -60,7 +60,7 @@ impl From<IntGridCell> for RigidBody {
     }
 }
 
-pub fn ease_movement(
+fn ease_movement(
     mut commands: Commands,
     mut grid_coords_query: Query<
         (
@@ -121,7 +121,7 @@ fn push_grid_coords_recursively(
     }
 }
 
-pub fn perform_grid_coords_movement(
+fn perform_grid_coords_movement(
     mut grid_coords_query: Query<(
         Entity,
         &mut GridCoords,
@@ -187,7 +187,7 @@ pub fn perform_grid_coords_movement(
     }
 }
 
-pub fn move_table_update(
+fn move_table_update(
     mut table_query: Query<(&GridCoords, &mut MoveTable)>,
     input_block_query: Query<(&GridCoords, &InputBlock)>,
 ) {

--- a/src/sokoban.rs
+++ b/src/sokoban.rs
@@ -1,3 +1,4 @@
+//! Plugin and components providing functionality for sokoban-style movement and collision.
 use crate::gameplay::Direction;
 use crate::{
     gameplay::{components::*, xy_translation},
@@ -7,6 +8,7 @@ use crate::{
 use bevy::prelude::*;
 use bevy_easings::*;
 
+/// Plugin providing functionality for sokoban-style movement and collision.
 pub struct SokobanPlugin;
 
 impl Plugin for SokobanPlugin {
@@ -36,6 +38,7 @@ impl Plugin for SokobanPlugin {
     }
 }
 
+/// Component defining the behavior of sokoban entities on collision.
 #[derive(Copy, Clone, Eq, PartialEq, Debug, Hash, Component)]
 pub enum RigidBody {
     Static,
@@ -187,6 +190,7 @@ fn perform_grid_coords_movement(
     }
 }
 
+// TODO: move to movement_table module once it is created
 fn move_table_update(
     mut table_query: Query<(&GridCoords, &mut MoveTable)>,
     input_block_query: Query<(&GridCoords, &InputBlock)>,

--- a/src/sokoban.rs
+++ b/src/sokoban.rs
@@ -7,6 +7,24 @@ use crate::{
 use bevy::prelude::*;
 use bevy_easings::*;
 
+#[derive(Copy, Clone, Eq, PartialEq, Debug, Hash, Component)]
+pub enum RigidBody {
+    Static,
+    Dynamic,
+}
+
+impl From<EntityInstance> for RigidBody {
+    fn from(_: EntityInstance) -> RigidBody {
+        RigidBody::Dynamic
+    }
+}
+
+impl From<IntGridCell> for RigidBody {
+    fn from(_: IntGridCell) -> RigidBody {
+        RigidBody::Static
+    }
+}
+
 pub fn ease_movement(
     mut commands: Commands,
     mut grid_coords_query: Query<

--- a/src/sugar.rs
+++ b/src/sugar.rs
@@ -1,123 +1,10 @@
-use crate::gameplay::Direction;
 use crate::{
-    animation::SpriteSheetAnimation,
-    gameplay::{components::*, xy_translation, *},
-    history::HistoryCommands,
+    gameplay::{components::*, *},
     resources::*,
     *,
 };
-use bevy::{prelude::*, utils::Duration};
-use bevy_easings::*;
+use bevy::prelude::*;
 use std::{cmp, ops::Range};
-
-pub fn ease_movement(
-    mut commands: Commands,
-    mut grid_coords_query: Query<
-        (
-            Entity,
-            &GridCoords,
-            &Transform,
-            Option<&PlayerAnimationState>,
-        ),
-        (Changed<GridCoords>, Without<MoveTable>),
-    >,
-) {
-    for (entity, &grid_coords, transform, player_state) in grid_coords_query.iter_mut() {
-        let mut xy = xy_translation(grid_coords.into());
-
-        if let Some(PlayerAnimationState::Push(direction)) = player_state {
-            xy += IVec2::from(*direction).as_vec2() * 5.;
-        }
-
-        commands.entity(entity).insert(transform.ease_to(
-            Transform::from_xyz(xy.x, xy.y, transform.translation.z),
-            EaseFunction::CubicOut,
-            EasingType::Once {
-                duration: std::time::Duration::from_millis(110),
-            },
-        ));
-    }
-}
-
-pub fn reset_player_easing(
-    mut commands: Commands,
-    player_query: Query<
-        (Entity, &GridCoords, &Transform, &PlayerAnimationState),
-        Changed<PlayerAnimationState>,
-    >,
-) {
-    if let Ok((entity, &grid_coords, transform, player_animation_state)) = player_query.get_single()
-    {
-        match player_animation_state {
-            PlayerAnimationState::Push(_) => (),
-            _ => {
-                let xy = xy_translation(grid_coords.into());
-                commands.entity(entity).insert(transform.ease_to(
-                    Transform::from_xyz(xy.x, xy.y, transform.translation.z),
-                    EaseFunction::CubicOut,
-                    EasingType::Once {
-                        duration: std::time::Duration::from_millis(110),
-                    },
-                ));
-            }
-        }
-    }
-}
-
-#[derive(Copy, Clone, Eq, PartialEq, Debug, Component)]
-pub enum PlayerAnimationState {
-    Idle(Direction),
-    Push(Direction),
-    Dying,
-    None,
-}
-
-impl Default for PlayerAnimationState {
-    fn default() -> Self {
-        PlayerAnimationState::Idle(Direction::Down)
-    }
-}
-
-impl Iterator for PlayerAnimationState {
-    type Item = Self;
-    fn next(&mut self) -> Option<Self::Item> {
-        Some(match self {
-            PlayerAnimationState::Dying | PlayerAnimationState::None => PlayerAnimationState::None,
-            PlayerAnimationState::Push(d) => PlayerAnimationState::Idle(*d),
-            _ => PlayerAnimationState::Idle(Direction::Down),
-        })
-    }
-}
-
-impl From<PlayerAnimationState> for SpriteSheetAnimation {
-    fn from(state: PlayerAnimationState) -> SpriteSheetAnimation {
-        use Direction::*;
-        use PlayerAnimationState::*;
-
-        let indices = match state {
-            Push(Up) => 1..2,
-            Push(Down) => 11..12,
-            Push(Left) => 21..22,
-            Push(Right) => 31..32,
-            Idle(Up) => 40..47,
-            Idle(Down) => 50..57,
-            Idle(Left) => 60..67,
-            Idle(Right) => 70..77,
-            Dying => 80..105,
-            None => 3..4,
-        };
-
-        let frame_timer = Timer::new(Duration::from_millis(150), true);
-
-        let repeat = matches!(state, Idle(Down));
-
-        SpriteSheetAnimation {
-            indices,
-            frame_timer,
-            repeat,
-        }
-    }
-}
 
 #[derive(Copy, Clone, Eq, PartialEq, Debug, Hash)]
 pub enum HandDirection {
@@ -159,34 +46,6 @@ impl GoalGhostAnimation {
             frames_since_blink: 0,
             frames_since_turn: 0,
             state: GoalAnimationState::default(),
-        }
-    }
-}
-
-pub fn history_sugar(
-    mut history_commands: EventReader<HistoryCommands>,
-    mut player_query: Query<&mut PlayerAnimationState>,
-    audio: Res<Audio>,
-    sfx: Res<AssetHolder>,
-) {
-    for command in history_commands.iter() {
-        match command {
-            HistoryCommands::Rewind | HistoryCommands::Reset => {
-                *player_query.single_mut() = PlayerAnimationState::Idle(Direction::Down);
-                audio.play(sfx.undo_sound.clone_weak());
-            }
-            _ => (),
-        }
-    }
-}
-
-pub fn play_death_animations(
-    mut player_query: Query<&mut PlayerAnimationState>,
-    mut death_event_reader: EventReader<DeathEvent>,
-) {
-    for DeathEvent { player_entity } in death_event_reader.iter() {
-        if let Ok(mut player_animation_state) = player_query.get_mut(*player_entity) {
-            *player_animation_state = PlayerAnimationState::Dying;
         }
     }
 }

--- a/src/willo.rs
+++ b/src/willo.rs
@@ -27,7 +27,8 @@ impl Plugin for WilloPlugin {
                     .run_in_state(GameState::Gameplay)
                     .after(SystemLabels::MoveTableUpdate)
                     .after(history::FlushHistoryCommands),
-            ) // Systems with potential easing end/beginning collisions cannot be in CoreStage::Update
+            )
+            // Systems with potential easing end/beginning collisions cannot be in CoreStage::Update
             // see https://github.com/vleue/bevy_easings/issues/23
             .add_system_to_stage(
                 CoreStage::PostUpdate,
@@ -63,7 +64,7 @@ impl Default for WilloState {
 const MOVEMENT_SECONDS: f32 = 0.14;
 
 #[derive(Clone, Debug, Component)]
-pub struct MovementTimer(pub Timer);
+struct MovementTimer(Timer);
 
 impl Default for MovementTimer {
     fn default() -> MovementTimer {
@@ -127,21 +128,21 @@ impl From<WilloAnimationState> for SpriteSheetAnimation {
 }
 
 #[derive(Clone, Bundle, LdtkEntity)]
-pub struct WilloBundle {
+struct WilloBundle {
     #[grid_coords]
-    pub grid_coords: GridCoords,
-    pub history: History<GridCoords>,
+    grid_coords: GridCoords,
+    history: History<GridCoords>,
     #[from_entity_instance]
-    pub rigid_body: RigidBody,
-    pub willo_state: WilloState,
-    pub movement_timer: MovementTimer,
+    rigid_body: RigidBody,
+    willo_state: WilloState,
+    movement_timer: MovementTimer,
     #[sprite_sheet_bundle]
     #[bundle]
-    pub sprite_sheet_bundle: SpriteSheetBundle,
-    pub willo_animation_state: WilloAnimationState,
+    sprite_sheet_bundle: SpriteSheetBundle,
+    willo_animation_state: WilloAnimationState,
 }
 
-pub fn reset_willo_easing(
+fn reset_willo_easing(
     mut commands: Commands,
     willo_query: Query<
         (Entity, &GridCoords, &Transform, &WilloAnimationState),
@@ -165,7 +166,7 @@ pub fn reset_willo_easing(
     }
 }
 
-pub fn history_sugar(
+fn history_sugar(
     mut history_commands: EventReader<HistoryCommands>,
     mut willo_query: Query<&mut WilloAnimationState>,
     audio: Res<Audio>,
@@ -182,7 +183,7 @@ pub fn history_sugar(
     }
 }
 
-pub fn play_death_animations(
+fn play_death_animations(
     mut willo_query: Query<&mut WilloAnimationState>,
     mut death_event_reader: EventReader<DeathEvent>,
 ) {
@@ -193,7 +194,7 @@ pub fn play_death_animations(
     }
 }
 
-pub fn move_willo_by_table(
+fn move_willo_by_table(
     table_query: Query<&MoveTable>,
     mut willo_query: Query<(&mut MovementTimer, &mut WilloState)>,
     mut movement_writer: EventWriter<WilloMovementEvent>,
@@ -236,7 +237,7 @@ pub fn move_willo_by_table(
     }
 }
 
-pub fn willo_input(
+fn willo_input(
     mut willo_query: Query<&mut WilloState>,
     input: Res<Input<KeyCode>>,
     mut history_commands: EventWriter<HistoryCommands>,

--- a/src/willo.rs
+++ b/src/willo.rs
@@ -6,6 +6,7 @@ use crate::{
     },
     gameplay::{xy_translation, *},
     history::HistoryCommands,
+    resources::{RewindSettings, RewindTimer},
     *,
 };
 use bevy::{prelude::*, utils::Duration};
@@ -176,6 +177,61 @@ pub fn move_player_by_table(
                     }
                     _ => {}
                 }
+            }
+        }
+    }
+}
+
+pub fn player_state_input(
+    mut player_query: Query<&mut PlayerState>,
+    input: Res<Input<KeyCode>>,
+    mut history_commands: EventWriter<HistoryCommands>,
+    mut rewind_settings: ResMut<RewindSettings>,
+    time: Res<Time>,
+) {
+    for mut player in player_query.iter_mut() {
+        if *player == PlayerState::Waiting {
+            if input.just_pressed(KeyCode::W) {
+                history_commands.send(HistoryCommands::Record);
+                *player = PlayerState::RankMove(KeyCode::W)
+            } else if input.just_pressed(KeyCode::A) {
+                history_commands.send(HistoryCommands::Record);
+                *player = PlayerState::RankMove(KeyCode::A)
+            } else if input.just_pressed(KeyCode::S) {
+                history_commands.send(HistoryCommands::Record);
+                *player = PlayerState::RankMove(KeyCode::S)
+            } else if input.just_pressed(KeyCode::D) {
+                history_commands.send(HistoryCommands::Record);
+                *player = PlayerState::RankMove(KeyCode::D)
+            }
+        }
+
+        if *player == PlayerState::Waiting || *player == PlayerState::Dead {
+            if input.just_pressed(KeyCode::Z) {
+                history_commands.send(HistoryCommands::Rewind);
+                *player = PlayerState::Waiting;
+                rewind_settings.hold_timer =
+                    Some(RewindTimer::new(rewind_settings.hold_range_millis.end));
+            } else if input.pressed(KeyCode::Z) {
+                let range = rewind_settings.hold_range_millis.clone();
+                let acceleration = rewind_settings.hold_acceleration;
+
+                if let Some(RewindTimer { velocity, timer }) = &mut rewind_settings.hold_timer {
+                    *velocity = (*velocity - (acceleration * time.delta_seconds()))
+                        .clamp(range.start as f32, range.end as f32);
+
+                    timer.tick(time.delta());
+
+                    if timer.just_finished() {
+                        history_commands.send(HistoryCommands::Rewind);
+                        *player = PlayerState::Waiting;
+
+                        timer.set_duration(Duration::from_millis(*velocity as u64));
+                    }
+                }
+            } else if input.just_pressed(KeyCode::R) {
+                history_commands.send(HistoryCommands::Reset);
+                *player = PlayerState::Waiting;
             }
         }
     }

--- a/src/willo.rs
+++ b/src/willo.rs
@@ -1,7 +1,7 @@
 use crate::gameplay::Direction;
 use crate::{
     animation::SpriteSheetAnimation,
-    gameplay::{components::*, xy_translation, *},
+    gameplay::{xy_translation, *},
     history::HistoryCommands,
     *,
 };
@@ -24,35 +24,6 @@ pub enum PlayerState {
 impl Default for PlayerState {
     fn default() -> PlayerState {
         PlayerState::Waiting
-    }
-}
-
-pub fn ease_movement(
-    mut commands: Commands,
-    mut grid_coords_query: Query<
-        (
-            Entity,
-            &GridCoords,
-            &Transform,
-            Option<&PlayerAnimationState>,
-        ),
-        (Changed<GridCoords>, Without<MoveTable>),
-    >,
-) {
-    for (entity, &grid_coords, transform, player_state) in grid_coords_query.iter_mut() {
-        let mut xy = xy_translation(grid_coords.into());
-
-        if let Some(PlayerAnimationState::Push(direction)) = player_state {
-            xy += IVec2::from(*direction).as_vec2() * 5.;
-        }
-
-        commands.entity(entity).insert(transform.ease_to(
-            Transform::from_xyz(xy.x, xy.y, transform.translation.z),
-            EaseFunction::CubicOut,
-            EasingType::Once {
-                duration: std::time::Duration::from_millis(110),
-            },
-        ));
     }
 }
 

--- a/src/willo.rs
+++ b/src/willo.rs
@@ -1,3 +1,4 @@
+//! Plugin, components and events providing functionality for Willo, the player character.
 use crate::{
     animation::SpriteSheetAnimation,
     gameplay::{components::MoveTable, Direction},
@@ -10,6 +11,7 @@ use crate::{
 use bevy::{prelude::*, utils::Duration};
 use bevy_easings::*;
 
+/// Plugin providing functionality for Willo, the player character.
 pub struct WilloPlugin;
 
 impl Plugin for WilloPlugin {
@@ -42,11 +44,15 @@ impl Plugin for WilloPlugin {
     }
 }
 
+/// Event that fires whenever Willo moves.
+///
+/// Only fires once per direction - so it fires twice during most moves.
 #[derive(Copy, Clone, Eq, PartialEq, Debug, Hash)]
 pub struct WilloMovementEvent {
     pub direction: Direction,
 }
 
+/// The main component for Willo, keeping track of their state.
 #[derive(Copy, Clone, Eq, PartialEq, Debug, Hash, Component)]
 pub enum WilloState {
     Waiting,
@@ -72,6 +78,7 @@ impl Default for MovementTimer {
     }
 }
 
+/// Component enumerating the possible states of Willo's animation.
 #[derive(Copy, Clone, Eq, PartialEq, Debug, Component)]
 pub enum WilloAnimationState {
     Idle(Direction),

--- a/src/willo.rs
+++ b/src/willo.rs
@@ -1,0 +1,165 @@
+use crate::gameplay::Direction;
+use crate::{
+    animation::SpriteSheetAnimation,
+    gameplay::{components::*, xy_translation, *},
+    history::HistoryCommands,
+    *,
+};
+use bevy::{prelude::*, utils::Duration};
+use bevy_easings::*;
+
+#[derive(Copy, Clone, Eq, PartialEq, Debug, Hash)]
+pub struct PlayerMovementEvent {
+    pub direction: Direction,
+}
+
+#[derive(Copy, Clone, Eq, PartialEq, Debug, Hash, Component)]
+pub enum PlayerState {
+    Waiting,
+    Dead,
+    RankMove(KeyCode),
+    FileMove(KeyCode),
+}
+
+impl Default for PlayerState {
+    fn default() -> PlayerState {
+        PlayerState::Waiting
+    }
+}
+
+pub fn ease_movement(
+    mut commands: Commands,
+    mut grid_coords_query: Query<
+        (
+            Entity,
+            &GridCoords,
+            &Transform,
+            Option<&PlayerAnimationState>,
+        ),
+        (Changed<GridCoords>, Without<MoveTable>),
+    >,
+) {
+    for (entity, &grid_coords, transform, player_state) in grid_coords_query.iter_mut() {
+        let mut xy = xy_translation(grid_coords.into());
+
+        if let Some(PlayerAnimationState::Push(direction)) = player_state {
+            xy += IVec2::from(*direction).as_vec2() * 5.;
+        }
+
+        commands.entity(entity).insert(transform.ease_to(
+            Transform::from_xyz(xy.x, xy.y, transform.translation.z),
+            EaseFunction::CubicOut,
+            EasingType::Once {
+                duration: std::time::Duration::from_millis(110),
+            },
+        ));
+    }
+}
+
+pub fn reset_player_easing(
+    mut commands: Commands,
+    player_query: Query<
+        (Entity, &GridCoords, &Transform, &PlayerAnimationState),
+        Changed<PlayerAnimationState>,
+    >,
+) {
+    if let Ok((entity, &grid_coords, transform, player_animation_state)) = player_query.get_single()
+    {
+        match player_animation_state {
+            PlayerAnimationState::Push(_) => (),
+            _ => {
+                let xy = xy_translation(grid_coords.into());
+                commands.entity(entity).insert(transform.ease_to(
+                    Transform::from_xyz(xy.x, xy.y, transform.translation.z),
+                    EaseFunction::CubicOut,
+                    EasingType::Once {
+                        duration: std::time::Duration::from_millis(110),
+                    },
+                ));
+            }
+        }
+    }
+}
+
+#[derive(Copy, Clone, Eq, PartialEq, Debug, Component)]
+pub enum PlayerAnimationState {
+    Idle(Direction),
+    Push(Direction),
+    Dying,
+    None,
+}
+
+impl Default for PlayerAnimationState {
+    fn default() -> Self {
+        PlayerAnimationState::Idle(Direction::Down)
+    }
+}
+
+impl Iterator for PlayerAnimationState {
+    type Item = Self;
+    fn next(&mut self) -> Option<Self::Item> {
+        Some(match self {
+            PlayerAnimationState::Dying | PlayerAnimationState::None => PlayerAnimationState::None,
+            PlayerAnimationState::Push(d) => PlayerAnimationState::Idle(*d),
+            _ => PlayerAnimationState::Idle(Direction::Down),
+        })
+    }
+}
+
+impl From<PlayerAnimationState> for SpriteSheetAnimation {
+    fn from(state: PlayerAnimationState) -> SpriteSheetAnimation {
+        use Direction::*;
+        use PlayerAnimationState::*;
+
+        let indices = match state {
+            Push(Up) => 1..2,
+            Push(Down) => 11..12,
+            Push(Left) => 21..22,
+            Push(Right) => 31..32,
+            Idle(Up) => 40..47,
+            Idle(Down) => 50..57,
+            Idle(Left) => 60..67,
+            Idle(Right) => 70..77,
+            Dying => 80..105,
+            None => 3..4,
+        };
+
+        let frame_timer = Timer::new(Duration::from_millis(150), true);
+
+        let repeat = matches!(state, Idle(Down));
+
+        SpriteSheetAnimation {
+            indices,
+            frame_timer,
+            repeat,
+        }
+    }
+}
+
+pub fn history_sugar(
+    mut history_commands: EventReader<HistoryCommands>,
+    mut player_query: Query<&mut PlayerAnimationState>,
+    audio: Res<Audio>,
+    sfx: Res<AssetHolder>,
+) {
+    for command in history_commands.iter() {
+        match command {
+            HistoryCommands::Rewind | HistoryCommands::Reset => {
+                *player_query.single_mut() = PlayerAnimationState::Idle(Direction::Down);
+                audio.play(sfx.undo_sound.clone_weak());
+            }
+            _ => (),
+        }
+    }
+}
+
+pub fn play_death_animations(
+    mut player_query: Query<&mut PlayerAnimationState>,
+    mut death_event_reader: EventReader<DeathEvent>,
+) {
+    for DeathEvent { player_entity } in death_event_reader.iter() {
+        if let Ok(mut player_animation_state) = player_query.get_mut(*player_entity) {
+            *player_animation_state = PlayerAnimationState::Dying;
+        }
+    }
+}


### PR DESCRIPTION
This PR exclusively moves items to the new modules, no logic updates (other than the typical Plugin modularization)

#60
- willo module with most of player animation and input logic
- rename Player items to Willo items
- sokoban module for core grid-based movement and pushing (pertains to players, walls, AND gravestones)