### PR TITLE
docs: document remaining missing docs and warn on missing docs

### DIFF
--- a/src/animation.rs
+++ b/src/animation.rs
@@ -29,6 +29,7 @@ impl Plugin for SpriteSheetAnimationPlugin {
 /// Event that fires at certain points during an animation.
 #[derive(Copy, Clone, Eq, PartialEq, Debug, Hash)]
 pub enum AnimationEvent {
+    /// Event that fires when an animation finishes, storing the animated entity.
     Finished(Entity),
 }
 
@@ -36,8 +37,17 @@ pub enum AnimationEvent {
 /// behaviour.
 #[derive(Clone, Debug, Default, Component)]
 pub struct SpriteSheetAnimation {
+    /// The range of indices of the texture atlas that provide the frames of the animation.
     pub indices: Range<usize>,
+    /// Timer that defines the duration of a frame in the animation and tracks its progress.
+    ///
+    /// Currently, the timer mode must be repeating.
+    // TODO: provide a constructor privatizing this field so it's always repeating.
     pub frame_timer: Timer,
+    /// Whether the animation should loop or not.
+    ///
+    /// Note: Animations that loop never fire [AnimationEvent::Finished], and can never
+    /// automatically transition to another animation in an animation graph.
     pub repeat: bool,
 }
 

--- a/src/animation.rs
+++ b/src/animation.rs
@@ -113,6 +113,15 @@ where
 {
     /// Basic constructor for [FromComponentAnimator].
     pub fn new() -> Self {
+        Self::default()
+    }
+}
+
+impl<F> Default for FromComponentAnimator<F>
+where
+    F: Into<SpriteSheetAnimation> + Component + 'static + Send + Sync + Clone + Iterator<Item = F>,
+{
+    fn default() -> Self {
         FromComponentAnimator {
             from_type: PhantomData,
         }

--- a/src/event_scheduler.rs
+++ b/src/event_scheduler.rs
@@ -27,6 +27,15 @@ where
 {
     /// Construct a new [EventSchedulerPlugin].
     pub fn new() -> Self {
+        Self::default()
+    }
+}
+
+impl<E> Default for EventSchedulerPlugin<E>
+where
+    E: 'static + Send + Sync,
+{
+    fn default() -> Self {
         EventSchedulerPlugin::<E> { data: PhantomData }
     }
 }

--- a/src/from_component.rs
+++ b/src/from_component.rs
@@ -30,6 +30,16 @@ where
 {
     /// Construct a new [FromComponentPlugin].
     pub fn new() -> Self {
+        Self::default()
+    }
+}
+
+impl<F, I> Default for FromComponentPlugin<F, I>
+where
+    F: Into<I> + Component + 'static + Send + Sync + Clone,
+    I: Component + 'static + Send + Sync,
+{
+    fn default() -> Self {
         FromComponentPlugin {
             from_type: PhantomData,
             into_type: PhantomData,

--- a/src/graveyard/exorcism.rs
+++ b/src/graveyard/exorcism.rs
@@ -14,6 +14,7 @@ use std::time::Duration;
 /// Labels used by exorcism systems.
 #[derive(SystemLabel)]
 pub enum ExorcismLabels {
+    /// Label used by the system that checks Willo's position kills Willo if appropriate.
     CheckDeath,
 }
 

--- a/src/graveyard/gravestone.rs
+++ b/src/graveyard/gravestone.rs
@@ -59,9 +59,13 @@ impl Plugin for GravestonePlugin {
     Actionlike, Copy, Clone, PartialEq, Eq, Debug, Hash, Component, Serialize, Deserialize,
 )]
 pub enum GraveId {
+    /// Gravestone/action that applies to "northy" buttons like W and Triangle.
     North,
+    /// Gravestone/action that applies to "westy" buttons like A and Square.
     West,
+    /// Gravestone/action that applies to "southy" buttons like S and X/Cross.
     South,
+    /// Gravestone/action that applies to "northy" buttons like D and Circle.
     East,
 }
 

--- a/src/graveyard/mod.rs
+++ b/src/graveyard/mod.rs
@@ -59,8 +59,11 @@ impl Plugin for GraveyardPlugin {
 /// Actions other than grave-actions that can be performed during the gameplay state.
 #[derive(Actionlike, Copy, Clone, PartialEq, Eq, Debug, Hash, Serialize, Deserialize)]
 pub enum GraveyardAction {
+    /// Undo the last grave-action or restart.
     Undo,
+    /// Restart the level to its initial state.
     Restart,
+    /// Pause the graveyard state and open up the pause menu.
     Pause,
 }
 

--- a/src/graveyard/mod.rs
+++ b/src/graveyard/mod.rs
@@ -2,14 +2,14 @@
 //!
 //! So, the logic for core gameplay lives here.
 
-mod control_display;
-mod exorcism;
-mod goal;
-mod gravestone;
-mod movement_table;
-mod sokoban;
+pub mod control_display;
+pub mod exorcism;
+pub mod goal;
+pub mod gravestone;
+pub mod movement_table;
+pub mod sokoban;
 pub mod willo;
-mod wind;
+pub mod wind;
 
 use crate::{
     history::{FlushHistoryCommands, HistoryCommands},

--- a/src/graveyard/movement_table.rs
+++ b/src/graveyard/movement_table.rs
@@ -37,9 +37,13 @@ impl Plugin for MovementTablePlugin {
 /// Enumerates the four directions that are exposed on the movement table.
 #[derive(Copy, Clone, Eq, PartialEq, Debug, Hash)]
 pub enum Direction {
+    /// North direction.
     Up,
+    /// West direction.
     Left,
+    /// South direction.
     Down,
+    /// East direction.
     Right,
 }
 

--- a/src/graveyard/sokoban.rs
+++ b/src/graveyard/sokoban.rs
@@ -15,7 +15,9 @@ use iyes_loopless::prelude::*;
 /// Labels used by sokoban systems
 #[derive(SystemLabel)]
 pub enum SokobanLabels {
+    /// Label for the system that updates the visual position of sokoban entities via bevy_easings.
     EaseMovement,
+    /// Label for the system that updates the logical position of sokoban entities.
     GridCoordsMovement,
 }
 
@@ -47,7 +49,9 @@ impl Plugin for SokobanPlugin {
 /// Component defining the behavior of sokoban entities on collision.
 #[derive(Copy, Clone, Eq, PartialEq, Debug, Hash, Component)]
 pub enum RigidBody {
+    /// The entity cannot move, push, or be pushed - but can block movement.
     Static,
+    /// The entity can move, push, or be pushed.
     Dynamic,
 }
 

--- a/src/graveyard/willo.rs
+++ b/src/graveyard/willo.rs
@@ -19,6 +19,7 @@ use std::time::Duration;
 /// Labels used by Willo systems.
 #[derive(SystemLabel)]
 pub enum WilloLabels {
+    /// TODO: replace this with graveyard-level label since this is no longer used in this module.
     Input,
 }
 
@@ -48,18 +49,27 @@ impl Plugin for WilloPlugin {
 
 /// Event that fires whenever Willo moves.
 ///
-/// Only fires once per direction - so it fires twice during most moves.
+/// Only fires once per direction - so it fires twice during most grave actions.
 #[derive(Copy, Clone, Eq, PartialEq, Debug, Hash)]
 pub struct WilloMovementEvent {
+    /// The direction that willo just performed as part of their grave action.
     pub direction: Direction,
 }
 
 /// Component that marks Willo and keeps track of their state.
 #[derive(Copy, Clone, Eq, PartialEq, Debug, Hash, Component)]
 pub enum WilloState {
+    /// Willo is idle, waiting for input.
     Waiting,
+    /// Willo is dead and cannot accept input.
     Dead,
+    /// Willo is performing the first part of a grave action.
+    ///
+    /// This move is defined by the rank of the gravestone on the movement table.
     RankMove(GraveId),
+    /// Willo is performing the second part of a grave action.
+    ///
+    /// This move is defined by the file of the gravestone on the movement table.
     FileMove(GraveId),
 }
 
@@ -72,9 +82,13 @@ impl Default for WilloState {
 /// Component enumerating the possible states of Willo's animation.
 #[derive(Copy, Clone, Eq, PartialEq, Debug, Component)]
 pub enum WilloAnimationState {
+    /// Willo is Idle, and facing a particular direction.
     Idle(Direction),
+    /// Willo is pushing a gravestione in a particular direction.
     Push(Direction),
+    /// Willo is dying.
     Dying,
+    /// Willo is invisible (post-death).
     None,
 }
 

--- a/src/history.rs
+++ b/src/history.rs
@@ -38,8 +38,15 @@ where
 /// Event that can be fired by the user to command the plugin to perform various history tasks.
 #[derive(Copy, Clone, Eq, PartialEq, Debug, Hash)]
 pub enum HistoryCommands {
+    /// Record the current state of all tracked components to their histories.
     Record,
+    /// Update the current state of all tracked components with the previous state and remove it
+    /// from the history.
     Rewind,
+    /// Update the current state of all tracked components to the first state in the history.
+    ///
+    /// Note: This also records the current state to the history before updating it.
+    /// This allows the act of resetting the history to be rewound via [HistoryCommands::Rewind].
     Reset,
 }
 

--- a/src/level_select.rs
+++ b/src/level_select.rs
@@ -200,11 +200,10 @@ fn unpause(mut commands: Commands, input: Res<ActionState<GraveyardAction>>) {
 
 fn select_level(mut commands: Commands, mut ui_actions: EventReader<UiAction>) {
     for action in ui_actions.iter() {
-        if let UiAction::GoToLevel(level_selection) = action {
-            commands.insert_resource(NextState(GameState::Graveyard));
-            commands.insert_resource(TransitionTo(level_selection.clone()));
-            commands.insert_resource(NextState(GameState::LevelTransition));
-        }
+        let UiAction::GoToLevel(level_selection) = action;
+        commands.insert_resource(NextState(GameState::Graveyard));
+        commands.insert_resource(TransitionTo(level_selection.clone()));
+        commands.insert_resource(NextState(GameState::LevelTransition));
     }
 }
 

--- a/src/main.rs
+++ b/src/main.rs
@@ -3,17 +3,17 @@
 #![allow(clippy::too_many_arguments, clippy::type_complexity)]
 #![warn(missing_docs)]
 
-mod animation;
-mod camera;
-mod event_scheduler;
-mod from_component;
-mod graveyard;
-mod history;
-mod level_select;
-mod level_transition;
-mod nine_slice;
-mod previous_component;
-mod ui;
+pub mod animation;
+pub mod camera;
+pub mod event_scheduler;
+pub mod from_component;
+pub mod graveyard;
+pub mod history;
+pub mod level_select;
+pub mod level_transition;
+pub mod nine_slice;
+pub mod previous_component;
+pub mod ui;
 
 use animation::SpriteSheetAnimationPlugin;
 use bevy::prelude::*;

--- a/src/main.rs
+++ b/src/main.rs
@@ -1,7 +1,7 @@
 //! TODO: provide crate documentation after writing README.
 // these two lints are triggered by normal system code a lot
 #![allow(clippy::too_many_arguments, clippy::type_complexity)]
-#![deny(missing_docs)]
+#![warn(missing_docs)]
 
 mod animation;
 mod camera;

--- a/src/main.rs
+++ b/src/main.rs
@@ -1,5 +1,7 @@
+//! TODO: provide crate documentation after writing README.
 // these two lints are triggered by normal system code a lot
 #![allow(clippy::too_many_arguments, clippy::type_complexity)]
+#![deny(missing_docs)]
 
 mod animation;
 mod camera;
@@ -21,16 +23,22 @@ use bevy_easings::EasingsPlugin;
 use bevy_ecs_ldtk::prelude::*;
 use iyes_loopless::prelude::*;
 
+/// Length of the sides of tiles on the game-grid in bevy's coordinate space.
 pub const UNIT_LENGTH: i32 = 32;
 
 #[cfg(feature = "inspector")]
 use bevy_inspector_egui::prelude::*;
 
+/// All possible bevy states that the game can be in.
 #[derive(Copy, Clone, Eq, PartialEq, Debug, Hash)]
 pub enum GameState {
+    /// Initial state of the game that perpares assets with `bevy_asset_loader`.
     AssetLoading,
+    /// State that facilitates level transitions, see [level_transition].
     LevelTransition,
+    /// State for the core gameplay that takes place on graveyards, see [graveyard].
     Graveyard,
+    /// State for the level select menu, see [level_select].
     LevelSelect,
 }
 
@@ -86,22 +94,33 @@ fn main() {
     app.run()
 }
 
+/// Asset collection loaded during the `GameState::AssetLoading` state.
+///
+/// Each field provides a handle for a different core asset of the game.
 #[derive(Debug, Default, AssetCollection, Resource)]
 pub struct AssetHolder {
+    /// Handle for all the LDtk info (level design).
     #[asset(path = "levels/willos-graveyard.ldtk")]
     pub ldtk: Handle<LdtkAsset>,
+    /// Handle for the game's spooky font.
     #[asset(path = "fonts/WayfarersToyBoxRegular-gxxER.ttf")]
     pub font: Handle<Font>,
+    /// Handle for the image used to underline text on text buttons.
     #[asset(path = "textures/button-underline.png")]
     pub button_underline: Handle<Image>,
+    /// Handle for the image used to highlight buttons on hover.
     #[asset(path = "textures/button-radial.png")]
     pub button_radial: Handle<Image>,
+    /// Handle for the sound that plays on level completion.
     #[asset(path = "sfx/victory.wav")]
     pub victory_sound: Handle<AudioSource>,
+    /// Handle for the sound that plays when Willo pushes a gravestone.
     #[asset(path = "sfx/push.wav")]
     pub push_sound: Handle<AudioSource>,
+    /// Handle for the sound that plays when the player hits undo/reset.
     #[asset(path = "sfx/undo.wav")]
     pub undo_sound: Handle<AudioSource>,
+    /// Handle for the tarot-card-inspired 9-slice image.
     #[asset(path = "textures/tarot.png")]
     pub tarot_sheet: Handle<Image>,
 }

--- a/src/previous_component.rs
+++ b/src/previous_component.rs
@@ -1,4 +1,4 @@
-//! Provides a generic component + plugin for tracking the previous value of other components.
+//! Plugin for tracking the previous value of a component via an additional generic component.
 //!
 //! Similar to the [crate::history] API, but keeps track of only one change.
 use bevy::prelude::*;
@@ -9,7 +9,7 @@ use std::marker::PhantomData;
 #[derive(Copy, Clone, Eq, PartialEq, Debug, Default, Hash, SystemLabel)]
 pub struct TrackPreviousComponent;
 
-/// Generic plugin for updating [PreviousComponent]s.
+/// Plugin for tracking the previous value of a component via an additional generic component.
 ///
 /// You'll need to insert this plugin to the app multiple times for every component you want to track.
 #[derive(Copy, Clone, Eq, PartialEq, Debug, Default, Hash)]
@@ -31,6 +31,7 @@ pub struct PreviousComponent<C: Component> {
 }
 
 impl<C: Component> PreviousComponent<C> {
+    /// Gets the previous value for the tracked component `C` on this entity.
     pub fn get(&self) -> &C {
         &self.last
     }

--- a/src/ui/actions.rs
+++ b/src/ui/actions.rs
@@ -12,9 +12,7 @@ use bevy_ecs_ldtk::prelude::*;
 #[allow(dead_code)]
 #[derive(Clone, Eq, PartialEq, Debug, Component)]
 pub enum UiAction {
-    Debug(&'static str),
-    RestartLevel,
-    NextLevel,
+    /// Action used by the level select menu to kick off a level transition.
     GoToLevel(LevelSelection),
 }
 

--- a/src/ui/font_scale.rs
+++ b/src/ui/font_scale.rs
@@ -25,11 +25,19 @@ impl Plugin for FontScalePlugin {
 #[allow(dead_code)]
 #[derive(Copy, Clone, PartialEq, Debug)]
 pub enum FontSize {
+    /// A tiny font size, good for footnotes.
     Tiny,
+    /// A small font size, good for description bodies.
     Small,
+    /// A medium font size, good for button text and sub-titles.
     Medium,
+    /// A large font size, good for section titles.
     Large,
+    /// A huge font size, good for menu titles.
     Huge,
+    /// A custom font size defined by the font size ratio.
+    ///
+    /// See [FontSizeRatios] for more details on font size ratios.
     Custom(f32),
 }
 
@@ -61,15 +69,20 @@ impl From<FontSize> for FontScale {
 /// wide screens, and `desired_font_size / given_screen_width` for tall screens.
 #[derive(Copy, Clone, PartialEq, Debug, Resource)]
 pub struct FontSizeRatios {
+    /// Font size ratio corresponding to [FontSize::Tiny]
     pub tiny: f32,
+    /// Font size ratio corresponding to [FontSize::Small]
     pub small: f32,
+    /// Font size ratio corresponding to [FontSize::Medium]
     pub medium: f32,
+    /// Font size ratio corresponding to [FontSize::Large]
     pub large: f32,
+    /// Font size ratio corresponding to [FontSize::Huge]
     pub huge: f32,
 }
 
 impl FontSizeRatios {
-    pub fn get(&self, font_size: &FontSize) -> f32 {
+    fn get(&self, font_size: &FontSize) -> f32 {
         match font_size {
             FontSize::Tiny => self.tiny,
             FontSize::Small => self.small,


### PR DESCRIPTION
Closes #72

Clippy fails for now due the following not being merged...
- #84 clippy fixes
- #82, #85, #86 provides missing docs
- #83 deletes an enum variant with missing docs

Otherwise, this finishes documenting the rest of the game. The `#![warn(missing_docs)]` makes CI fail when documentation for public items isn't provided, but allows the game to compile during development regardless.