### PR TITLE
feat: add UiAtlasImagePlugin

### DIFF
--- a/src/main.rs
+++ b/src/main.rs
@@ -15,6 +15,7 @@ pub mod nine_slice;
 pub mod previous_component;
 pub mod sokoban;
 pub mod ui;
+pub mod ui_atlas_image;
 
 use animation::SpriteSheetAnimationPlugin;
 use bevy::prelude::*;

--- a/src/ui_atlas_image.rs
+++ b/src/ui_atlas_image.rs
@@ -14,6 +14,7 @@ impl Plugin for UiAtlasImagePlugin {
     }
 }
 
+/// Resource that caches TextureAtlases and their corresponding images.
 #[derive(Debug, Default, Deref, DerefMut, Resource)]
 struct UiAtlasImageMap(HashMap<Handle<TextureAtlas>, Vec<Handle<Image>>>);
 

--- a/src/ui_atlas_image.rs
+++ b/src/ui_atlas_image.rs
@@ -9,10 +9,10 @@ impl Plugin for UiAtlasImagePlugin {
     }
 }
 
-#[derive(Deref, DerefMut, Resource)]
+#[derive(Debug, Default, Deref, DerefMut, Resource)]
 struct UiAtlasImageMap(HashMap<Handle<TextureAtlas>, Vec<Handle<Image>>>);
 
-#[derive(Component)]
+#[derive(Clone, Debug, Default, Component)]
 pub struct UiAtlasImage {
     pub texture_atlas: Handle<TextureAtlas>,
     pub index: usize,

--- a/src/ui_atlas_image.rs
+++ b/src/ui_atlas_image.rs
@@ -1,6 +1,10 @@
+//! Plugin for displaying images in the UI from a TextureAtlas.
 use bevy::prelude::*;
 use std::collections::HashMap;
 
+/// Plugin for displaying images in the UI from a TextureAtlas.
+///
+/// Use the [UiAtlasImage] component to employ this plugin.
 pub struct UiAtlasImagePlugin;
 
 impl Plugin for UiAtlasImagePlugin {
@@ -13,9 +17,16 @@ impl Plugin for UiAtlasImagePlugin {
 #[derive(Debug, Default, Deref, DerefMut, Resource)]
 struct UiAtlasImageMap(HashMap<Handle<TextureAtlas>, Vec<Handle<Image>>>);
 
+/// Component that defines a UiAtlasImage.
+///
+/// The plugin will respond to changes in this component.
+/// First, it generates plain [Image](bevy::render::Image)s based off the textures in the texture atlas.
+/// Using these images, it will insert the appropriate [UiImage](bevy::render::UiImage) on your entity.
 #[derive(Clone, Debug, Default, Component)]
 pub struct UiAtlasImage {
+    /// Atlas that defines the texture and its partitions.
     pub texture_atlas: Handle<TextureAtlas>,
+    /// Index of the texture partition to display on this entity.
     pub index: usize,
 }
 

--- a/src/ui_atlas_image.rs
+++ b/src/ui_atlas_image.rs
@@ -32,6 +32,12 @@ pub struct UiAtlasImage {
     pub index: usize,
 }
 
+#[derive(Debug, Default, Bundle)]
+pub struct AtlasImageBundle {
+    pub image_bundle: ImageBundle,
+    pub atlas_image: UiAtlasImage,
+}
+
 fn resolve_ui_atlas_image(
     mut commands: Commands,
     mut map: ResMut<UiAtlasImageMap>,

--- a/src/ui_atlas_image.rs
+++ b/src/ui_atlas_image.rs
@@ -1,4 +1,5 @@
 use bevy::prelude::*;
+use std::collections::HashMap;
 
 pub struct UiAtlasImagePlugin;
 
@@ -11,7 +12,53 @@ impl Plugin for UiAtlasImagePlugin {
 #[derive(Deref, DerefMut, Resource)]
 struct UiAtlasImageMap(HashMap<Handle<TextureAtlas>, Vec<Handle<Image>>>);
 
-struct UiAtlasImage {
-    texture_atlas: Handle<TextureAtlas>,
-    index: usize,
+#[derive(Component)]
+pub struct UiAtlasImage {
+    pub texture_atlas: Handle<TextureAtlas>,
+    pub index: usize,
+}
+
+fn populate_ui_atlas_image(
+    mut commands: Commands,
+    mut map: ResMut<UiAtlasImageMap>,
+    ui_atlas_images: Query<(Entity, &UiAtlasImage), Changed<UiAtlasImage>>,
+    mut images: ResMut<Assets<Image>>,
+    atlases: Res<Assets<TextureAtlas>>,
+) {
+    for (entity, ui_atlas_image) in &ui_atlas_images {
+        let images = map
+            .entry(ui_atlas_image.texture_atlas.clone())
+            .or_insert_with(|| {
+                let atlas = atlases.get(&ui_atlas_image.texture_atlas).unwrap();
+
+                let image = images
+                    .get(&atlas.texture)
+                    .unwrap()
+                    .clone()
+                    .try_into_dynamic()
+                    .unwrap(); // TODO: can we handle these errors better?
+
+                atlas
+                    .textures
+                    .iter()
+                    .map(|rect| {
+                        let crop = Image::from_dynamic(
+                            image.crop_imm(
+                                rect.min.x as u32,
+                                rect.min.y as u32,
+                                rect.width() as u32,
+                                rect.height() as u32,
+                            ),
+                            false, // TODO: what should this be?
+                        );
+
+                        images.add(crop)
+                    })
+                    .collect()
+            });
+
+        commands
+            .entity(entity)
+            .insert(UiImage(images[ui_atlas_image.index].clone()));
+    }
 }

--- a/src/ui_atlas_image.rs
+++ b/src/ui_atlas_image.rs
@@ -31,25 +31,24 @@ fn populate_ui_atlas_image(
             .or_insert_with(|| {
                 let atlas = atlases.get(&ui_atlas_image.texture_atlas).unwrap();
 
-                let image = images
-                    .get(&atlas.texture)
-                    .unwrap()
-                    .clone()
-                    .try_into_dynamic()
-                    .unwrap(); // TODO: can we handle these errors better?
+                let image = images.get(&atlas.texture).unwrap();
+
+                let is_srgb = image.texture_descriptor.format.describe().srgb;
+
+                let dynamic_image = image.clone().try_into_dynamic().unwrap(); // TODO: can we handle these errors better?
 
                 atlas
                     .textures
                     .iter()
                     .map(|rect| {
                         let crop = Image::from_dynamic(
-                            image.crop_imm(
+                            dynamic_image.crop_imm(
                                 rect.min.x as u32,
                                 rect.min.y as u32,
                                 rect.width() as u32,
                                 rect.height() as u32,
                             ),
-                            false, // TODO: what should this be?
+                            is_srgb,
                         );
 
                         images.add(crop)

--- a/src/ui_atlas_image.rs
+++ b/src/ui_atlas_image.rs
@@ -1,3 +1,4 @@
+#![allow(dead_code)]
 //! Plugin for displaying images in the UI from a TextureAtlas.
 use bevy::prelude::*;
 use std::collections::HashMap;

--- a/src/ui_atlas_image.rs
+++ b/src/ui_atlas_image.rs
@@ -5,7 +5,8 @@ pub struct UiAtlasImagePlugin;
 
 impl Plugin for UiAtlasImagePlugin {
     fn build(&self, app: &mut App) {
-        todo!();
+        app.init_resource::<UiAtlasImageMap>()
+            .add_system(resolve_ui_atlas_image);
     }
 }
 
@@ -18,7 +19,7 @@ pub struct UiAtlasImage {
     pub index: usize,
 }
 
-fn populate_ui_atlas_image(
+fn resolve_ui_atlas_image(
     mut commands: Commands,
     mut map: ResMut<UiAtlasImageMap>,
     ui_atlas_images: Query<(Entity, &UiAtlasImage), Changed<UiAtlasImage>>,

--- a/src/ui_atlas_image.rs
+++ b/src/ui_atlas_image.rs
@@ -134,18 +134,20 @@ mod tests {
             .add(texture_atlas)
     }
 
-    #[test]
-    fn map_and_image_resolve() {
-        let mut app = app_setup();
-        let texture_atlas = generate_texture_atlas(&mut app);
-
-        let ui_atlas_image_entity = app
-            .world
+    fn spawn_ui_atlas_image_entity(app: &mut App, texture_atlas: Handle<TextureAtlas>) -> Entity {
+        app.world
             .spawn(UiAtlasImage {
                 texture_atlas: texture_atlas.clone(),
                 index: 1,
             })
-            .id();
+            .id()
+    }
+
+    #[test]
+    fn map_and_image_resolve() {
+        let mut app = app_setup();
+        let texture_atlas = generate_texture_atlas(&mut app);
+        let ui_atlas_image_entity = spawn_ui_atlas_image_entity(&mut app, texture_atlas.clone());
 
         app.update();
 
@@ -184,14 +186,7 @@ mod tests {
     fn index_changes_dont_generate_more_images() {
         let mut app = app_setup();
         let texture_atlas = generate_texture_atlas(&mut app);
-
-        let ui_atlas_image_entity = app
-            .world
-            .spawn(UiAtlasImage {
-                texture_atlas: texture_atlas.clone(),
-                index: 1,
-            })
-            .id();
+        let ui_atlas_image_entity = spawn_ui_atlas_image_entity(&mut app, texture_atlas.clone());
 
         app.update();
 

--- a/src/ui_atlas_image.rs
+++ b/src/ui_atlas_image.rs
@@ -29,13 +29,17 @@ fn populate_ui_atlas_image(
         let images = map
             .entry(ui_atlas_image.texture_atlas.clone())
             .or_insert_with(|| {
-                let atlas = atlases.get(&ui_atlas_image.texture_atlas).unwrap();
+                let atlas = atlases
+                    .get(&ui_atlas_image.texture_atlas)
+                    .expect("Handle used in UiAtlasImage should be in Assets<TextureAtlas>");
 
-                let image = images.get(&atlas.texture).unwrap();
+                let image = images
+                    .get(&atlas.texture)
+                    .expect("source image for UiAtlasImage should be in Assets<Image>");
 
                 let is_srgb = image.texture_descriptor.format.describe().srgb;
 
-                let dynamic_image = image.clone().try_into_dynamic().unwrap(); // TODO: can we handle these errors better?
+                let dynamic_image = image.clone().try_into_dynamic().expect("source image for UiAtlasImage should support dynamic conversion: https://docs.rs/bevy/latest/bevy/render/texture/struct.Image.html#method.try_into_dynamic");
 
                 atlas
                     .textures

--- a/src/ui_atlas_image.rs
+++ b/src/ui_atlas_image.rs
@@ -1,0 +1,17 @@
+use bevy::prelude::*;
+
+pub struct UiAtlasImagePlugin;
+
+impl Plugin for UiAtlasImagePlugin {
+    fn build(&self, app: &mut App) {
+        todo!();
+    }
+}
+
+#[derive(Deref, DerefMut, Resource)]
+struct UiAtlasImageMap(HashMap<Handle<TextureAtlas>, Vec<Handle<Image>>>);
+
+struct UiAtlasImage {
+    texture_atlas: Handle<TextureAtlas>,
+    index: usize,
+}

--- a/src/ui_atlas_image.rs
+++ b/src/ui_atlas_image.rs
@@ -32,10 +32,14 @@ pub struct UiAtlasImage {
     pub index: usize,
 }
 
+/// Bundle for [UiAtlasImage] and the components it needs to render.
 #[derive(Debug, Default, Bundle)]
 pub struct AtlasImageBundle {
-    pub image_bundle: ImageBundle,
+    /// The [UiAtlasImage] for this entity.
     pub atlas_image: UiAtlasImage,
+    /// The plugin just generates a UiImage on the entity.
+    /// So, an ImageBundle will always contain everything it needs to render properly.
+    pub image_bundle: ImageBundle,
 }
 
 fn resolve_ui_atlas_image(


### PR DESCRIPTION
Adds a plugin for displaying images in the UI from texture atlases. This doesn't do anything with shaders, it just generates images from a `TextureAtlas` (provided by a public component), and then uses that to insert a `UiImage` component on that entity. This PR doesn't use this plugin anywhere in the game, but I plan to use it in future PRs updating the control display heavily.