### PR TITLE
fix: upgrade bevy_inspector_egui for dev feature

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -22,7 +22,7 @@ serde = "1"
 serde_json = "1"
 bevy_asset_loader = { version = "0.14", features = ["stageless"] }
 iyes_loopless = "0.9"
-bevy-inspector-egui = { version = "0.13", optional = true }
+bevy-inspector-egui = { version = "0.17", optional = true }
 thiserror = "1"
 leafwing-input-manager = "0.7"
 

--- a/src/main.rs
+++ b/src/main.rs
@@ -28,7 +28,7 @@ use iyes_loopless::prelude::*;
 pub const UNIT_LENGTH: i32 = 32;
 
 #[cfg(feature = "inspector")]
-use bevy_inspector_egui::prelude::*;
+use bevy_inspector_egui::quick::WorldInspectorPlugin;
 
 /// All possible bevy states that the game can be in.
 #[derive(Copy, Clone, Eq, PartialEq, Debug, Hash)]
@@ -89,7 +89,7 @@ fn main() {
 
     #[cfg(feature = "inspector")]
     {
-        app.add_plugin(WorldInspectorPlugin::new());
+        app.add_plugin(WorldInspectorPlugin);
     }
 
     app.run()


### PR DESCRIPTION
I haven't used the `dev` feature in a while and it turns out its main dependency, `bevy_ecs_egui`, hasn't been upgraded. To get the `dev` feature to compile again I had to upgrade that dependency and deal with its breaking changes.