### PR TITLE
build: use lld instead of zld in MacOS builds

### DIFF
--- a/.cargo/config.toml
+++ b/.cargo/config.toml
@@ -7,13 +7,21 @@
 linker = "clang"
 rustflags = ["-Clink-arg=-fuse-ld=lld", "-Zshare-generics=y"]
 
-# NOTE: you must manually install https://github.com/michaeleisel/zld on mac. you can easily do this with the "brew" package manager:
-# `brew install michaeleisel/zld/zld`
+# NOTE: you must install [Mach-O LLD Port](https://lld.llvm.org/MachO/index.html) on mac. you can easily do this by installing llvm which includes lld with the "brew" package manager:
+# `brew install llvm`
 [target.x86_64-apple-darwin]
-rustflags = ["-C", "link-arg=-fuse-ld=/usr/local/bin/zld", "-Zshare-generics=y"]
+rustflags = [
+    "-C",
+    "link-arg=-fuse-ld=/usr/local/opt/llvm/bin/ld64.lld",
+    "-Zshare-generics=y",
+]
 
 [target.aarch64-apple-darwin]
-rustflags = ["-C", "link-arg=-fuse-ld=/opt/homebrew/bin/zld", "-Zshare-generics=y"]
+rustflags = [
+    "-C",
+    "link-arg=-fuse-ld=/opt/homebrew/opt/llvm/bin/ld64.lld",
+    "-Zshare-generics=y",
+]
 
 [target.x86_64-pc-windows-msvc]
 linker = "rust-lld.exe"

--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -137,9 +137,9 @@ jobs:
         run: |
           export CFLAGS="-fno-stack-check"
           export MACOSX_DEPLOYMENT_TARGET="10.9"
-      - name: install zld
+      - name: install llvm
         run: |
-          brew install michaeleisel/zld/zld
+          brew install llvm
       - name: Build
         run: |
           cargo build --release --target x86_64-apple-darwin --no-default-features


### PR DESCRIPTION
The most recent release CI for this game failed for MacOS (but succeeded elsewhere): https://github.com/Trouv/willos-graveyard/actions/runs/6729366432/job/18290122998

In particular, it failed to install `zld`, a linker available for MacOS. It turns out that this linker has been archived, and now bevy recommends just using `llvm`/`lld` for mac fast-compile: https://bevyengine.org/learn/book/getting-started/setup/#enable-fast-compiles-optional

This PR resolves this by switching the cargo config to use lld on mac, and the CI to install llvm before build.