### PR TITLE
refactor: add Volatile plugin abstracting death-on-contact logic

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -17,6 +17,7 @@ inspector = ["bevy-inspector-egui"]
 bevy = { version = "0.11", features = ["wav"] }
 bevy_easings = "0.11.1"
 bevy_ecs_ldtk = "0.8"
+bevy_ecs_tilemap = "0.11"
 rand = "0.8"
 serde = "1"
 serde_json = "1"

--- a/src/graveyard/exorcism.rs
+++ b/src/graveyard/exorcism.rs
@@ -4,9 +4,8 @@ use crate::{
         volatile::{Sublimation, Volatile},
         willo::WilloState,
     },
-    history::{FlushHistoryCommands, History},
+    history::History,
     ui::font_scale::{FontScale, FontSize},
-    utils::any_match_filter,
     GameState,
 };
 use bevy::prelude::*;

--- a/src/graveyard/exorcism.rs
+++ b/src/graveyard/exorcism.rs
@@ -12,6 +12,7 @@ use crate::{
 use bevy::prelude::*;
 use bevy_easings::*;
 use bevy_ecs_ldtk::prelude::*;
+use bevy_ecs_tilemap::tiles::TileVisible;
 use std::time::Duration;
 
 /// Sets used by exorcism systems.
@@ -34,6 +35,7 @@ impl Plugin for ExorcismPlugin {
                         .run_if(in_state(GameState::Graveyard))
                         .in_set(ExorcismSets::CheckDeath)
                         .after(Sublimation),
+                    visually_sublimate_volatile_tiles.run_if(in_state(GameState::Graveyard)),
                     spawn_death_card.run_if(in_state(GameState::Graveyard)),
                 ),
             )
@@ -65,6 +67,14 @@ fn check_death(
             *willo = WilloState::Dead;
             death_event_writer.send(ExorcismEvent);
         }
+    }
+}
+
+fn visually_sublimate_volatile_tiles(
+    mut volatile_tile_query: Query<(&mut TileVisible, &Volatile), Changed<Volatile>>,
+) {
+    for (mut visibility, volatile) in volatile_tile_query.iter_mut() {
+        visibility.0 = volatile.is_solid();
     }
 }
 

--- a/src/graveyard/exorcism.rs
+++ b/src/graveyard/exorcism.rs
@@ -42,10 +42,6 @@ impl Plugin for ExorcismPlugin {
     }
 }
 
-/// Component that marks exorcism tiles.
-#[derive(Copy, Clone, Eq, PartialEq, Debug, Default, Hash, Component)]
-struct ExorcismTile;
-
 /// Event that fires when willo steps on an exorcism tile.
 #[derive(Copy, Clone, Eq, PartialEq, Debug, Hash, Event)]
 pub struct ExorcismEvent;

--- a/src/graveyard/mod.rs
+++ b/src/graveyard/mod.rs
@@ -7,6 +7,7 @@ pub mod exorcism;
 pub mod goal;
 pub mod gravestone;
 pub mod movement_table;
+pub mod volatile;
 pub mod wall;
 pub mod willo;
 pub mod wind;

--- a/src/graveyard/mod.rs
+++ b/src/graveyard/mod.rs
@@ -51,6 +51,7 @@ impl Plugin for GraveyardPlugin {
                 sokoban::SokobanPlugin::new(GameState::Graveyard, "IntGrid"),
                 movement_table::MovementTablePlugin,
                 gravestone::GravestonePlugin,
+                volatile::VolatilePlugin,
                 wall::WallPlugin,
                 goal::GoalPlugin,
                 exorcism::ExorcismPlugin,

--- a/src/graveyard/volatile.rs
+++ b/src/graveyard/volatile.rs
@@ -1,0 +1,12 @@
+use bevy::prelude::*;
+
+/// Component defining the volatility of an entity and its volatile state.
+///
+/// If two volatile solids share the same space, they both are sublimated.
+/// What this means for a particular entity should be defined elsewhere.
+#[derive(Copy, Clone, Debug, Default, PartialEq, Eq, Component)]
+pub enum Volatile {
+    #[default]
+    Solid,
+    Sublimated,
+}

--- a/src/graveyard/volatile.rs
+++ b/src/graveyard/volatile.rs
@@ -24,10 +24,6 @@ impl Volatile {
     }
 }
 
-fn any_volatiles_moved(query: Query<(), (With<Volatile>, Changed<GridCoords>)>) -> bool {
-    !query.is_empty()
-}
-
 fn sublimation(
     moved_volatile_entities: Query<(), (With<Volatile>, Changed<GridCoords>)>,
     mut all_volatiles: Query<(Entity, &GridCoords, &mut Volatile), Changed<GridCoords>>,

--- a/src/graveyard/volatile.rs
+++ b/src/graveyard/volatile.rs
@@ -1,6 +1,22 @@
 use bevy::prelude::*;
 use bevy_ecs_ldtk::prelude::*;
 
+use crate::{history::FlushHistoryCommands, utils::any_match_filter, GameState};
+
+pub struct VolatilePlugin;
+
+impl Plugin for VolatilePlugin {
+    fn build(&self, app: &mut App) {
+        app.add_systems(
+            Update,
+            sublimation
+                .run_if(in_state(GameState::Graveyard))
+                .run_if(any_match_filter::<(With<Volatile>, Changed<GridCoords>)>)
+                .after(FlushHistoryCommands),
+        );
+    }
+}
+
 /// Component defining the volatility of an entity and its volatile state.
 ///
 /// If two volatile solids share the same [`GridCoords`] space, they both are sublimated.

--- a/src/graveyard/volatile.rs
+++ b/src/graveyard/volatile.rs
@@ -32,16 +32,16 @@ fn sublimation(
         .iter_mut()
         .partition(|(entity, ..)| moved_volatile_entities.contains(*entity));
 
-    for index in 1..moved_volatiles.len() {
-        let (head_moved_volatiles, remaining_moved_volatiles) = moved_volatiles.split_at_mut(index);
-
-        let (_, grid_coords_a, volatile_a) = head_moved_volatiles.last_mut().expect("TODO");
-
-        if volatile_a.is_solid() {
-            for (_, grid_coords_b, volatile_b) in remaining_moved_volatiles.iter_mut() {
-                if volatile_b.is_solid() && grid_coords_a == grid_coords_b {
-                    volatile_a.sublimate();
-                    volatile_b.sublimate();
+    for index in 0..moved_volatiles.len() - 1 {
+        if let [(_, grid_coords_a, volatile_a), remaining_moved_volatiles @ ..] =
+            &mut moved_volatiles[index..]
+        {
+            if volatile_a.is_solid() {
+                for (_, grid_coords_b, volatile_b) in remaining_moved_volatiles.iter_mut() {
+                    if volatile_b.is_solid() && grid_coords_a == grid_coords_b {
+                        volatile_a.sublimate();
+                        volatile_b.sublimate();
+                    }
                 }
             }
         }

--- a/src/graveyard/volatile.rs
+++ b/src/graveyard/volatile.rs
@@ -1,12 +1,15 @@
 use bevy::prelude::*;
+use bevy_ecs_ldtk::prelude::*;
 
 /// Component defining the volatility of an entity and its volatile state.
 ///
-/// If two volatile solids share the same space, they both are sublimated.
+/// If two volatile solids share the same [`GridCoords`] space, they both are sublimated.
 /// What this means for a particular entity should be defined elsewhere.
 #[derive(Copy, Clone, Debug, Default, PartialEq, Eq, Component)]
 pub enum Volatile {
+    /// The entity is still a volatile solid.
     #[default]
     Solid,
+    /// The entity has collided with another volatile solid, and has been subliminated.
     Sublimated,
 }

--- a/src/graveyard/volatile.rs
+++ b/src/graveyard/volatile.rs
@@ -51,10 +51,12 @@ pub enum Volatile {
 }
 
 impl Volatile {
+    /// Returns `true` if this instance is [`Volatile::Solid`].
     pub fn is_solid(&self) -> bool {
         matches!(self, Volatile::Solid)
     }
 
+    /// Sets this instance to [`Volatile::Sublimated`].
     pub fn sublimate(&mut self) {
         *self = Volatile::Sublimated;
     }

--- a/src/graveyard/volatile.rs
+++ b/src/graveyard/volatile.rs
@@ -17,7 +17,7 @@ use crate::{
 /// Once they come into contact with another Volatile entity - they are both "Sublimated".
 pub struct VolatilePlugin;
 
-/// `SystemSet` performing sublimation [`Volatile`] entities.
+/// `SystemSet` performing sublimation of [`Volatile`] entities.
 #[derive(Default, Debug, Copy, Clone, PartialEq, Eq, Hash, SystemSet)]
 pub struct Sublimation;
 
@@ -46,7 +46,7 @@ pub enum Volatile {
     /// The entity is still a volatile solid.
     #[default]
     Solid,
-    /// The entity has collided with another volatile solid, and has been subliminated.
+    /// The entity has collided with another volatile solid, and has been sublimated.
     Sublimated,
 }
 
@@ -64,7 +64,7 @@ impl Volatile {
 
 /// System performing sublimation logic.
 ///
-/// Obtains a separate query for moving volatiles from all volatiles.
+/// Obtains a separate query for *moving* volatiles and *all* volatiles.
 /// This is so it can split moving volatiles and stationary volatiles into separate collections.
 /// This allows us to limit our collision detection to checking moved-volatiles against all-volatiles,
 /// rather than all-volatiles against all-volatiles.

--- a/src/graveyard/volatile.rs
+++ b/src/graveyard/volatile.rs
@@ -24,14 +24,37 @@ impl Volatile {
     }
 }
 
-fn sublimation(mut volatile_query: Query<(&GridCoords, &mut Volatile)>) {
-    let mut combinations = volatile_query.iter_combinations_mut::<2>();
-    while let Some([(grid_coords_a, mut volatile_a), (grid_coords_b, mut volatile_b)]) =
-        combinations.fetch_next()
-    {
-        if grid_coords_a == grid_coords_b && volatile_a.is_solid() && volatile_b.is_solid() {
-            volatile_a.sublimate();
-            volatile_b.sublimate();
+fn sublimation(
+    moved_volatile_entities: Query<Entity, (With<Volatile>, Changed<GridCoords>)>,
+    mut all_volatiles: Query<(Entity, &GridCoords, &mut Volatile), Changed<GridCoords>>,
+) {
+    let (mut moved_volatiles, mut stationary_volatiles): (Vec<_>, Vec<_>) = all_volatiles
+        .iter_mut()
+        .partition(|(entity, ..)| moved_volatile_entities.contains(*entity));
+
+    for index in 1..moved_volatiles.len() {
+        let (head_moved_volatiles, remaining_moved_volatiles) = moved_volatiles.split_at_mut(index);
+
+        let (_, grid_coords_a, volatile_a) = head_moved_volatiles.last_mut().expect("TODO");
+
+        if volatile_a.is_solid() {
+            for (_, grid_coords_b, volatile_b) in remaining_moved_volatiles.iter_mut() {
+                if volatile_b.is_solid() && grid_coords_a == grid_coords_b {
+                    volatile_a.sublimate();
+                    volatile_b.sublimate();
+                }
+            }
+        }
+    }
+
+    for (_, grid_coords_a, volatile_a) in moved_volatiles.iter_mut() {
+        if volatile_a.is_solid() {
+            for (_, grid_coords_b, volatile_b) in stationary_volatiles.iter_mut() {
+                if volatile_b.is_solid() && grid_coords_a == grid_coords_b {
+                    volatile_a.sublimate();
+                    volatile_b.sublimate();
+                }
+            }
         }
     }
 }

--- a/src/graveyard/volatile.rs
+++ b/src/graveyard/volatile.rs
@@ -13,3 +13,25 @@ pub enum Volatile {
     /// The entity has collided with another volatile solid, and has been subliminated.
     Sublimated,
 }
+
+impl Volatile {
+    fn is_solid(&self) -> bool {
+        matches!(self, Volatile::Solid)
+    }
+
+    fn sublimate(&mut self) {
+        *self = Volatile::Sublimated;
+    }
+}
+
+fn sublimation(mut volatile_query: Query<(&GridCoords, &mut Volatile)>) {
+    let mut combinations = volatile_query.iter_combinations_mut::<2>();
+    while let Some([(grid_coords_a, mut volatile_a), (grid_coords_b, mut volatile_b)]) =
+        combinations.fetch_next()
+    {
+        if grid_coords_a == grid_coords_b && volatile_a.is_solid() && volatile_b.is_solid() {
+            volatile_a.sublimate();
+            volatile_b.sublimate();
+        }
+    }
+}

--- a/src/graveyard/volatile.rs
+++ b/src/graveyard/volatile.rs
@@ -14,7 +14,10 @@ pub struct Sublimation;
 
 impl Plugin for VolatilePlugin {
     fn build(&self, app: &mut App) {
-        app.add_systems(
+        app.add_plugins(HistoryPlugin::<Volatile, _>::run_in_state(
+            GameState::Graveyard,
+        ))
+        .add_systems(
             Update,
             sublimation
                 .run_if(in_state(GameState::Graveyard))

--- a/src/graveyard/volatile.rs
+++ b/src/graveyard/volatile.rs
@@ -1,9 +1,16 @@
 use bevy::prelude::*;
 use bevy_ecs_ldtk::prelude::*;
 
-use crate::{history::FlushHistoryCommands, utils::any_match_filter, GameState};
+use crate::{
+    history::{FlushHistoryCommands, HistoryPlugin},
+    utils::any_match_filter,
+    GameState,
+};
 
 pub struct VolatilePlugin;
+
+#[derive(Default, Debug, Copy, Clone, PartialEq, Eq, Hash, SystemSet)]
+pub struct Sublimation;
 
 impl Plugin for VolatilePlugin {
     fn build(&self, app: &mut App) {
@@ -12,7 +19,8 @@ impl Plugin for VolatilePlugin {
             sublimation
                 .run_if(in_state(GameState::Graveyard))
                 .run_if(any_match_filter::<(With<Volatile>, Changed<GridCoords>)>)
-                .after(FlushHistoryCommands),
+                .after(FlushHistoryCommands)
+                .in_set(Sublimation),
         );
     }
 }

--- a/src/graveyard/volatile.rs
+++ b/src/graveyard/volatile.rs
@@ -1,3 +1,7 @@
+//! Plugin providing the core logic for [`Volatile`] entities.
+//!
+//! Volatile entities are "Solid" initially.
+//! Once they come into contact with another Volatile entity - they are both "Sublimated".
 use bevy::prelude::*;
 use bevy_ecs_ldtk::prelude::*;
 
@@ -7,8 +11,13 @@ use crate::{
     GameState,
 };
 
+/// Plugin providing the core logic for [`Volatile`] entities.
+///
+/// Volatile entities are "Solid" initially.
+/// Once they come into contact with another Volatile entity - they are both "Sublimated".
 pub struct VolatilePlugin;
 
+/// `SystemSet` performing sublimation [`Volatile`] entities.
 #[derive(Default, Debug, Copy, Clone, PartialEq, Eq, Hash, SystemSet)]
 pub struct Sublimation;
 

--- a/src/graveyard/volatile.rs
+++ b/src/graveyard/volatile.rs
@@ -50,7 +50,7 @@ impl Volatile {
 
 fn sublimation(
     moved_volatile_entities: Query<(), (With<Volatile>, Changed<GridCoords>)>,
-    mut all_volatiles: Query<(Entity, &GridCoords, &mut Volatile), Changed<GridCoords>>,
+    mut all_volatiles: Query<(Entity, &GridCoords, &mut Volatile)>,
 ) {
     let (mut moved_volatiles, mut stationary_volatiles): (Vec<_>, Vec<_>) = all_volatiles
         .iter_mut()

--- a/src/graveyard/volatile.rs
+++ b/src/graveyard/volatile.rs
@@ -39,11 +39,11 @@ pub enum Volatile {
 }
 
 impl Volatile {
-    fn is_solid(&self) -> bool {
+    pub fn is_solid(&self) -> bool {
         matches!(self, Volatile::Solid)
     }
 
-    fn sublimate(&mut self) {
+    pub fn sublimate(&mut self) {
         *self = Volatile::Sublimated;
     }
 }

--- a/src/graveyard/volatile.rs
+++ b/src/graveyard/volatile.rs
@@ -24,8 +24,12 @@ impl Volatile {
     }
 }
 
+fn any_volatiles_moved(query: Query<(), (With<Volatile>, Changed<GridCoords>)>) -> bool {
+    !query.is_empty()
+}
+
 fn sublimation(
-    moved_volatile_entities: Query<Entity, (With<Volatile>, Changed<GridCoords>)>,
+    moved_volatile_entities: Query<(), (With<Volatile>, Changed<GridCoords>)>,
     mut all_volatiles: Query<(Entity, &GridCoords, &mut Volatile), Changed<GridCoords>>,
 ) {
     let (mut moved_volatiles, mut stationary_volatiles): (Vec<_>, Vec<_>) = all_volatiles

--- a/src/graveyard/willo.rs
+++ b/src/graveyard/willo.rs
@@ -2,7 +2,7 @@
 use crate::{
     animation::{FromComponentAnimator, SpriteSheetAnimation},
     from_component::FromComponentSet,
-    graveyard::{exorcism::ExorcismEvent, gravestone::GraveId},
+    graveyard::{exorcism::ExorcismEvent, gravestone::GraveId, volatile::Volatile},
     history::{History, HistoryCommands, HistoryPlugin},
     sokoban::{Direction, PushEvent, PushTracker, SokobanBlock, SokobanSets},
     AssetHolder, GameState, UNIT_LENGTH,
@@ -158,6 +158,8 @@ struct WilloBundle {
     #[sprite_sheet_bundle]
     sprite_sheet_bundle: SpriteSheetBundle,
     willo_animation_state: WilloAnimationState,
+    volatile: Volatile,
+    volatile_history: History<Volatile>,
 }
 
 fn push_sugar(

--- a/src/utils.rs
+++ b/src/utils.rs
@@ -1,7 +1,12 @@
 //! Common utilities that may be useful in many contexts.
-use bevy::prelude::*;
+use bevy::{ecs::query::ReadOnlyWorldQuery, prelude::*};
 
-/// Simple `iyes_loopless` run condition that passes if the resource has changed.
+/// Simple run condition that passes if the resource has changed.
 pub fn resource_changed<R: Resource>(resource: Res<R>) -> bool {
     resource.is_changed()
+}
+
+/// Simple run condition that passes if any entities match the filter.
+pub fn any_match_filter<F: ReadOnlyWorldQuery>(filter_query: Query<(), F>) -> bool {
+    !filter_query.is_empty()
 }


### PR DESCRIPTION
The game design of willos-graveyard is being adjusted. One change is to introduce an potential lock/key mechanism to the game. This will come in the form of gravestones/exorcism tiles destroying each other on contact. The thought is that this logic is similar to what happens between willo and exorcism tiles on contact - it's just that the meaning of "destruction" is different there. So, the purpose of this PR is to abstract the idea of "death on contact" into its own component/plugin.

The result is the `Volatile` component/plugin. `Volatile` entities are initially `Volatile::Solid`, but when they contact another `Volatile::Solid`, they both become `Volatile::Sublimated`. For Willo - this means game over. For exorcism tiles - this means going invisible and no longer being destructive. And, in a future PR, gravestones will also go invisible and stop having sokoban logic.

These values are tracked with `HistoryPlugin` and respond to history commands appropriately.