### PR TITLE
fix: use bevy_ecs_tilemap 0.11.1 instead of git dependency

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -17,7 +17,7 @@ inspector = ["bevy-inspector-egui"]
 bevy = { version = "0.11", features = ["wav"] }
 bevy_easings = "0.11.1"
 bevy_ecs_ldtk = "0.8"
-bevy_ecs_tilemap = "0.11"
+bevy_ecs_tilemap = "0.11.1"
 rand = "0.8"
 serde = "1"
 serde_json = "1"
@@ -28,6 +28,3 @@ leafwing-input-manager = "0.10"
 
 [target.wasm32-unknown-unknown.dependencies]
 bevy_ecs_ldtk = { version = "0.8", features = ["atlas"] }
-
-[patch.crates-io]
-bevy_ecs_tilemap = { git = "http://github.com/StarArawn/bevy_ecs_tilemap", version = "0.11", branch = "main" }


### PR DESCRIPTION
A git dependency was used for `bevy_ecs_tilemap` to pull in a fix for a bug that was in version `0.11`. This bug fix has since been released in version `0.11.1`, and now depending on main is broken since main has upgraded to `0.12`. This PR resolves this issue by removing the `bevy_ecs_tilemap` patch and depending on version `0.11.1`.