### PR TITLE
design: remove "3rd problem" in 'Barrier magic' and push it later in level order

### DIFF
--- a/assets/levels/willos-graveyard.ldtk
+++ b/assets/levels/willos-graveyard.ldtk
@@ -3584,35 +3584,6 @@
 			"__neighbours": []
 		},
 		{
-			"identifier": "Barrier_magic",
-			"iid": "b29ffab0-8990-11ee-acbd-9d768bae3bbd",
-			"uid": 227,
-			"worldX": -1,
-			"worldY": -1,
-			"worldDepth": 0,
-			"pxWid": 448,
-			"pxHei": 352,
-			"__bgColor": "#3A1847",
-			"bgColor": null,
-			"useAutoIdentifier": false,
-			"bgRelPath": null,
-			"bgPos": null,
-			"bgPivotX": 0.5,
-			"bgPivotY": 0.5,
-			"__smartColor": "#93809A",
-			"__bgPos": null,
-			"externalRelPath": "willos-graveyard/Barrier_magic.ldtkl",
-			"fieldInstances": [
-				{ "__identifier": "Title", "__type": "String", "__value": "Barrier magic", "__tile": null, "defUid": 28, "realEditorValues": [{
-					"id": "V_String",
-					"params": ["Barrier magic"]
-				}] },
-				{ "__identifier": "Notes", "__type": "String", "__value": null, "__tile": null, "defUid": 64, "realEditorValues": [] }
-			],
-			"layerInstances": null,
-			"__neighbours": []
-		},
-		{
 			"identifier": "Jaw",
 			"iid": "6cd29450-8990-11ee-8c53-99f34597fa75",
 			"uid": 224,
@@ -3664,6 +3635,35 @@
 				{ "__identifier": "Title", "__type": "String", "__value": "Marguerite", "__tile": null, "defUid": 28, "realEditorValues": [{
 					"id": "V_String",
 					"params": ["Marguerite"]
+				}] },
+				{ "__identifier": "Notes", "__type": "String", "__value": null, "__tile": null, "defUid": 64, "realEditorValues": [] }
+			],
+			"layerInstances": null,
+			"__neighbours": []
+		},
+		{
+			"identifier": "Barrier_magic",
+			"iid": "b29ffab0-8990-11ee-acbd-9d768bae3bbd",
+			"uid": 227,
+			"worldX": -1,
+			"worldY": -1,
+			"worldDepth": 0,
+			"pxWid": 448,
+			"pxHei": 352,
+			"__bgColor": "#3A1847",
+			"bgColor": null,
+			"useAutoIdentifier": false,
+			"bgRelPath": null,
+			"bgPos": null,
+			"bgPivotX": 0.5,
+			"bgPivotY": 0.5,
+			"__smartColor": "#93809A",
+			"__bgPos": null,
+			"externalRelPath": "willos-graveyard/Barrier_magic.ldtkl",
+			"fieldInstances": [
+				{ "__identifier": "Title", "__type": "String", "__value": "Barrier magic", "__tile": null, "defUid": 28, "realEditorValues": [{
+					"id": "V_String",
+					"params": ["Barrier magic"]
 				}] },
 				{ "__identifier": "Notes", "__type": "String", "__value": null, "__tile": null, "defUid": 64, "realEditorValues": [] }
 			],

--- a/assets/levels/willos-graveyard/Barrier_magic.ldtkl
+++ b/assets/levels/willos-graveyard/Barrier_magic.ldtkl
@@ -160,7 +160,7 @@
 				},
 				{
 					"__identifier": "S",
-					"__grid": [7,7],
+					"__grid": [8,7],
 					"__pivot": [0,0],
 					"__tags": [],
 					"__tile": { "tilesetUid": 21, "x": 192, "y": 16, "w": 16, "h": 16 },
@@ -169,7 +169,7 @@
 					"width": 32,
 					"height": 32,
 					"defUid": 24,
-					"px": [224,224],
+					"px": [256,224],
 					"fieldInstances": []
 				},
 				{
@@ -347,7 +347,7 @@
 				},
 				{
 					"__identifier": "Goal",
-					"__grid": [7,7],
+					"__grid": [8,7],
 					"__pivot": [0,0],
 					"__tags": [],
 					"__tile": { "tilesetUid": 4, "x": 0, "y": 96, "w": 32, "h": 32 },
@@ -356,7 +356,7 @@
 					"width": 32,
 					"height": 32,
 					"defUid": 18,
-					"px": [224,224],
+					"px": [256,224],
 					"fieldInstances": []
 				},
 				{


### PR DESCRIPTION
By pushing the goal 1 tile to the right in "barrier magic", the level becomes slightly simpler. Before, there were 3 problems the level presented the player.
1. How do you push a gravestone in front of the opening?
2. How do you recover the helper gravestone you used in problem 1?
3. How do you push a gravestone onto the right goal without overshooting?

Playtesting revealed that problem 3 obscured problem 2 too much. This change simplifies the level to get rid of problem 3 entirely.

Playtesting *also* revealed that the level is pretty hard. I'm pushing it to later in the level order for the next playtest.

![barrier-magic](https://github.com/Trouv/willos-graveyard/assets/15664670/99d93503-89de-4eb6-871e-2db79cd91888)
