### PR TITLE
chore: use bevy_ecs_ldtk 0.9 instead of patch and address clippy issues

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -16,7 +16,7 @@ inspector = ["bevy-inspector-egui"]
 [dependencies]
 bevy = { version = "0.12", features = ["wav"] }
 bevy_easings = "0.12"
-bevy_ecs_ldtk = { version = "0.8", default-features = false, features = ["derive", "render", "external_levels"] }
+bevy_ecs_ldtk = { version = "0.9", default-features = false, features = ["derive", "render", "external_levels"] }
 bevy_ecs_tilemap = "0.12"
 rand = "0.8"
 serde = "1"
@@ -27,8 +27,4 @@ thiserror = "1"
 leafwing-input-manager = "0.11"
 
 [target.wasm32-unknown-unknown.dependencies]
-bevy_ecs_ldtk = { version = "0.8", default-features = false, features = ["derive", "render", "external_levels", "atlas"] }
-
-[patch.crates-io]
-bevy_ecs_ldtk = { git = "https://github.com/Trouv/bevy_ecs_ldtk", branch = "main" }
-bevy_ecs_tilemap = { git = "https://github.com/StarArawn/bevy_ecs_tilemap", branch = "main" }
+bevy_ecs_ldtk = { version = "0.9", default-features = false, features = ["derive", "render", "external_levels", "atlas"] }

--- a/src/event_scheduler.rs
+++ b/src/event_scheduler.rs
@@ -72,12 +72,12 @@ where
     }
 }
 
-fn fire_scheduled_events<E: Event>(
+fn fire_scheduled_events<E>(
     time: Res<Time>,
     mut event_scheduler: ResMut<EventScheduler<E>>,
     mut writer: EventWriter<E>,
 ) where
-    E: 'static + Send + Sync,
+    E: 'static + Event + Send + Sync,
 {
     event_scheduler.events = event_scheduler
         .events

--- a/src/level_transition.rs
+++ b/src/level_transition.rs
@@ -112,10 +112,11 @@ fn spawn_level_card(
                     .level
                     + 1,
             );
-            title = selected_level
-                .get_string_field("Title")
-                .expect("all levels should have titles")
-                .clone();
+            title.clone_from(
+                selected_level
+                    .get_string_field("Title")
+                    .expect("all levels should have titles"),
+            );
         }
     }
 

--- a/src/nine_slice.rs
+++ b/src/nine_slice.rs
@@ -1,6 +1,5 @@
 //! Utilities for generating nine-slice images from texture atlases.
 use bevy::{
-    math::Rect,
     prelude::*,
     render::{
         render_resource::{Extent3d, TextureDimension},


### PR DESCRIPTION
The patch was a temporary resolution to be able to use bevy 0.12 and corresponding updates to other plugins. Now that `bevy_ecs_tilemap` 0.12 and `bevy_ecs_ldtk` 0.9 have been released, this patch can be removed.