### PR TITLE
fix: address clippy 1.84.0-nightly lints

### DIFF
--- a/src/animation.rs
+++ b/src/animation.rs
@@ -94,12 +94,12 @@ fn set_initial_sprite_index(
 /// To use this plugin, follow these steps:
 /// 1. Create an enum component of animation states.
 /// 2. Provide an implementation of `From` from your enum component to [SpriteSheetAnimation].
-/// This `From` implementation defines what specific animation settings are associated with
-/// variants of your animation state.
+///    This `From` implementation defines what specific animation settings are associated with
+///    variants of your animation state.
 /// 3. Provide an implementation of `Iterator` for your enum component with itself as the item.
-/// This `Iterator` implementation defines which states lead into other states, like an animation
-/// graph.
-/// Simply point an animation state to itself when it is complete.
+///    This `Iterator` implementation defines which states lead into other states, like an animation
+///    graph.
+///    Simply point an animation state to itself when it is complete.
 pub struct FromComponentAnimator<F>
 where
     F: Into<SpriteSheetAnimation> + Component + 'static + Send + Sync + Clone + Iterator<Item = F>,

--- a/src/graveyard/volatile.rs
+++ b/src/graveyard/volatile.rs
@@ -127,10 +127,11 @@ mod tests {
 
     impl<const N: usize> SpawnVolatilesParams<N> {
         fn new() -> SpawnVolatilesParams<N> {
-            let mut volatiles: [(GridCoords, Volatile); N] = [Default::default(); N];
-            for i in 0..N {
-                volatiles[i].0.y = i as i32;
-            }
+            let volatiles = (0..N as i32)
+                .map(|y| (GridCoords { x: 0, y }, Volatile::Solid))
+                .collect::<Vec<_>>()
+                .try_into()
+                .unwrap();
 
             SpawnVolatilesParams { volatiles }
         }

--- a/src/sokoban.rs
+++ b/src/sokoban.rs
@@ -118,7 +118,7 @@ pub struct SokobanCommands<'w> {
     writer: EventWriter<'w, SokobanCommand>,
 }
 
-impl<'w> SokobanCommands<'w> {
+impl SokobanCommands<'_> {
     /// Move a [SokobanBlock] entity in the given direction.
     ///
     /// Will perform the necessary collision checks and block pushes.


### PR DESCRIPTION
The clippy lint is currently failing on the main branch and many development branches. This performs some changes to satisfy the lint.