### PR TITLE
chore: address clippy lints (nightly 6/5/25)

### DIFF
--- a/src/main.rs
+++ b/src/main.rs
@@ -47,7 +47,7 @@ pub enum GameState {
 
 fn main() {
     let level_selection = if std::env::args().count() > 1 {
-        let level_arg = std::env::args().last().unwrap();
+        let level_arg = std::env::args().next_back().unwrap();
 
         match level_arg.parse::<usize>() {
             Ok(num) => LevelSelection::index(num - 1),


### PR DESCRIPTION
Code hasn't been merged to this repository for a long time. In that time, clippy has recieved some new lints which will cause new code (or currently-drafted code) to fail CI. This addresses all current lints.
