### PR TITLE
feat: overhaul SokobanPlugin to make it more functional and generic

### DIFF
--- a/src/graveyard/mod.rs
+++ b/src/graveyard/mod.rs
@@ -48,7 +48,7 @@ impl Plugin for GraveyardPlugin {
                 control_display::ControlDisplayPlugin,
                 willo::WilloPlugin,
                 movement_table::MovementTablePlugin,
-                sokoban::SokobanPlugin::<GameState, sokoban::SokobanBlock>::new(
+                sokoban::SokobanPlugin::<GameState, sokoban::SokobanBlock, sokoban::Direction>::new(
                     GameState::Graveyard,
                     "IntGrid",
                 ),

--- a/src/graveyard/mod.rs
+++ b/src/graveyard/mod.rs
@@ -6,7 +6,14 @@ pub mod control_display;
 pub mod exorcism;
 pub mod goal;
 pub mod gravestone;
+<<<<<<< HEAD
 pub mod movement_table;
+||||||| parent of a828bf0 (feat: add OutOfBoundsPlugin in GraveyardPlugin)
+pub mod gravestone_movement_queries;
+=======
+pub mod gravestone_movement_queries;
+pub mod out_of_bounds;
+>>>>>>> a828bf0 (feat: add OutOfBoundsPlugin in GraveyardPlugin)
 pub mod volatile;
 pub mod wall;
 pub mod willo;
@@ -54,6 +61,7 @@ impl Plugin for GraveyardPlugin {
                 goal::GoalPlugin,
                 exorcism::ExorcismPlugin,
                 wind::WindPlugin,
+                out_of_bounds::OutOfBoundsPlugin,
             ))
             .add_systems(
                 Update,

--- a/src/graveyard/mod.rs
+++ b/src/graveyard/mod.rs
@@ -6,14 +6,8 @@ pub mod control_display;
 pub mod exorcism;
 pub mod goal;
 pub mod gravestone;
-<<<<<<< HEAD
 pub mod movement_table;
-||||||| parent of a828bf0 (feat: add OutOfBoundsPlugin in GraveyardPlugin)
-pub mod gravestone_movement_queries;
-=======
-pub mod gravestone_movement_queries;
 pub mod out_of_bounds;
->>>>>>> a828bf0 (feat: add OutOfBoundsPlugin in GraveyardPlugin)
 pub mod volatile;
 pub mod wall;
 pub mod willo;
@@ -53,8 +47,11 @@ impl Plugin for GraveyardPlugin {
             .add_plugins((
                 control_display::ControlDisplayPlugin,
                 willo::WilloPlugin,
-                sokoban::SokobanPlugin::new(GameState::Graveyard, "IntGrid"),
                 movement_table::MovementTablePlugin,
+                sokoban::SokobanPlugin::<GameState, sokoban::SokobanBlock>::new(
+                    GameState::Graveyard,
+                    "IntGrid",
+                ),
                 gravestone::GravestonePlugin,
                 volatile::VolatilePlugin,
                 wall::WallPlugin,

--- a/src/graveyard/movement_table.rs
+++ b/src/graveyard/movement_table.rs
@@ -94,7 +94,7 @@ fn move_willo_by_table(
         &mut WilloState,
         &mut WilloAnimationState,
     )>,
-    mut sokoban_commands: SokobanCommands,
+    mut sokoban_commands: SokobanCommands<Direction>,
     time: Res<Time>,
 ) {
     for table in table_query.iter() {

--- a/src/graveyard/out_of_bounds.rs
+++ b/src/graveyard/out_of_bounds.rs
@@ -1,0 +1,62 @@
+use crate::{sokoban::SokobanBlock, utils::any_match_filter, AssetHolder, GameState, UNIT_LENGTH};
+use bevy::prelude::*;
+use bevy_ecs_ldtk::prelude::*;
+
+pub struct OutOfBoundsPlugin;
+
+impl Plugin for OutOfBoundsPlugin {
+    fn build(&self, app: &mut App) {
+        app.add_systems(
+            PreUpdate,
+            spawn_level_boundaries.run_if(any_match_filter::<Added<LevelIid>>.and_then(
+                in_state(GameState::Graveyard).or_else(in_state(GameState::LevelTransition)),
+            )),
+        );
+    }
+}
+
+fn spawn_level_boundaries(
+    mut commands: Commands,
+    level_iids: Query<(Entity, &LevelIid), Added<LevelIid>>,
+    ldtk_project_assets: Res<Assets<LdtkProject>>,
+    asset_holder: Res<AssetHolder>,
+) {
+    let ldtk_project = ldtk_project_assets
+        .get(&asset_holder.ldtk)
+        .expect("ldtk project should be loaded if LevelIids are spawned");
+    level_iids.for_each(|(level_entity, level_iid)| {
+        let level = ldtk_project
+            .get_raw_level_by_iid(level_iid.get())
+            .expect("spawned level should exist in ldtk project");
+
+        let level_grid_size = IVec2::new(level.px_wid, level.px_hei) / UNIT_LENGTH;
+
+        commands
+            .entity(level_entity)
+            .with_children(|child_commands| {
+                for x in -1..=level_grid_size.x {
+                    // spawn bottom wall
+                    child_commands
+                        .spawn(SokobanBlock::Static)
+                        .insert(GridCoords::new(x, -1));
+
+                    // spawn top wall
+                    child_commands
+                        .spawn(SokobanBlock::Static)
+                        .insert(GridCoords::new(x, level_grid_size.y));
+                }
+
+                for y in 0..level_grid_size.y {
+                    // spawn left wall
+                    child_commands
+                        .spawn(SokobanBlock::Static)
+                        .insert(GridCoords::new(-1, y));
+
+                    // spawn right wall
+                    child_commands
+                        .spawn(SokobanBlock::Static)
+                        .insert(GridCoords::new(level_grid_size.x, y));
+                }
+            });
+    })
+}

--- a/src/graveyard/out_of_bounds.rs
+++ b/src/graveyard/out_of_bounds.rs
@@ -1,7 +1,10 @@
+//! Contains [`OutOfBoundsPlugin`], which places invisible walls on level boundaries.
+
 use crate::{sokoban::SokobanBlock, utils::any_match_filter, AssetHolder, GameState, UNIT_LENGTH};
 use bevy::prelude::*;
 use bevy_ecs_ldtk::prelude::*;
 
+/// Plugin that spawns [`SokobanBlock::Static`] on the boundaries of LDtk levels.
 pub struct OutOfBoundsPlugin;
 
 impl Plugin for OutOfBoundsPlugin {

--- a/src/graveyard/willo.rs
+++ b/src/graveyard/willo.rs
@@ -35,7 +35,7 @@ impl Plugin for WilloPlugin {
             (
                 push_sugar
                     .run_if(not(in_state(GameState::AssetLoading)))
-                    .run_if(on_event::<PushEvent>())
+                    .run_if(on_event::<PushEvent<Direction>>())
                     .before(FromComponentSet),
                 play_exorcism_animaton
                     .run_if(not(in_state(GameState::AssetLoading)))
@@ -164,7 +164,7 @@ struct WilloBundle {
 
 fn push_sugar(
     mut commands: Commands,
-    mut push_events: EventReader<PushEvent>,
+    mut push_events: EventReader<PushEvent<Direction>>,
     mut willo_query: Query<(Entity, &mut WilloAnimationState)>,
     sfx: Res<AssetHolder>,
 ) {
@@ -191,7 +191,7 @@ fn push_translation(
     if let Ok((entity, &grid_coords, transform, animation_state)) = willo_query.get_single() {
         let xy = grid_coords_to_translation(grid_coords, IVec2::splat(UNIT_LENGTH))
             + match animation_state {
-                WilloAnimationState::Push(direction) => IVec2::from(direction).as_vec2() * 5.,
+                WilloAnimationState::Push(direction) => (IVec2::ZERO + direction).as_vec2() * 5.,
                 _ => Vec2::splat(0.),
             };
 

--- a/src/graveyard/willo.rs
+++ b/src/graveyard/willo.rs
@@ -109,16 +109,16 @@ impl From<WilloAnimationState> for SpriteSheetAnimation {
         use WilloAnimationState::*;
 
         let indices = match state {
-            Push(Up) => 1..2,
-            Push(Down) => 11..12,
+            Push(Up | UpLeft | UpRight) => 1..2,
+            Push(Down | DownLeft | DownRight) => 11..12,
             Push(Left) => 21..22,
             Push(Right) => 31..32,
-            Idle(Up) => 40..47,
-            Idle(Down) => 50..57,
+            Idle(Up | UpLeft | UpRight) => 40..47,
+            Idle(Down | DownLeft | DownRight) => 50..57,
             Idle(Left) => 60..67,
             Idle(Right) => 70..77,
             Dying => 80..105,
-            None => 3..4,
+            Idle(Zero) | Push(Zero) | None => 3..4,
         };
 
         let frame_timer = Timer::new(Duration::from_millis(150), TimerMode::Repeating);
@@ -191,7 +191,7 @@ fn push_translation(
     if let Ok((entity, &grid_coords, transform, animation_state)) = willo_query.get_single() {
         let xy = grid_coords_to_translation(grid_coords, IVec2::splat(UNIT_LENGTH))
             + match animation_state {
-                WilloAnimationState::Push(direction) => IVec2::from(*direction).as_vec2() * 5.,
+                WilloAnimationState::Push(direction) => IVec2::from(direction).as_vec2() * 5.,
                 _ => Vec2::splat(0.),
             };
 

--- a/src/sokoban.rs
+++ b/src/sokoban.rs
@@ -7,7 +7,7 @@
 use bevy::{ecs::system::SystemParam, prelude::*};
 use bevy_easings::*;
 use bevy_ecs_ldtk::{prelude::*, utils::grid_coords_to_translation};
-use std::ops::Add;
+use std::ops::{Add, AddAssign};
 use thiserror::Error;
 
 /// Sets used by sokoban systems
@@ -147,6 +147,12 @@ impl Add<Direction> for Direction {
 
     fn add(self, rhs: Direction) -> Self::Output {
         self.try_add(rhs).unwrap()
+    }
+}
+
+impl AddAssign for Direction {
+    fn add_assign(&mut self, rhs: Self) {
+        *self = *self + rhs;
     }
 }
 

--- a/src/sokoban.rs
+++ b/src/sokoban.rs
@@ -284,14 +284,12 @@ impl SokobanBlock {
 pub struct PushTracker;
 
 /// Event that fires when a [PushTracker] entity pushes other [SokobanBlock]s.
-#[derive(Debug, Clone, PartialEq, Eq, Event)]
+#[derive(Debug, Clone, PartialEq, Eq, Hash, Event)]
 pub struct PushEvent {
     /// The [PushTracker] entity that pushed other [SokobanBlock]s.
     pub pusher: Entity,
     /// The direction of the push.
     pub direction: Direction,
-    /// The list of [SokobanBlock] entities that were pushed.
-    pub pushed: Vec<Entity>,
 }
 
 fn ease_movement(

--- a/src/sokoban.rs
+++ b/src/sokoban.rs
@@ -103,16 +103,21 @@ struct SokobanLayerIdentifier(String);
 #[derive(Copy, Clone, Default, Eq, PartialEq, Debug, Hash, Reflect)]
 pub enum Direction {
     #[default]
+    /// No direction.
     Zero,
+    /// Northeast direction.
     UpRight,
     /// North direction.
     Up,
+    /// Northwest direction.
     UpLeft,
     /// West direction.
     Left,
+    /// Southwest direction.
     DownLeft,
     /// South direction.
     Down,
+    /// Southeast direction.
     DownRight,
     /// East direction.
     Right,
@@ -136,6 +141,7 @@ impl Add<&Direction> for IVec2 {
     }
 }
 
+/// Directions must have coordinates of 0s and 1s.
 #[derive(Debug, Error)]
 #[error("Directions must have coordinates of 0s and 1s")]
 pub struct OutOfBoundsDirection;
@@ -228,10 +234,13 @@ pub enum SokobanBlock {
     Dynamic,
 }
 
+/// Possible outcomes for a block that is pushing another block.
 #[derive(Copy, Clone, Debug, Default, PartialEq, Eq)]
 pub enum PusherResult {
+    /// The push was not blocked, the pusher can move in the direction of the push.
     #[default]
     NotBlocked,
+    /// The push was blocked, the pusher cannot move in the direction of the push.
     Blocked,
 }
 
@@ -244,21 +253,19 @@ impl PusherResult {
     }
 }
 
+/// Possible outcomes for a block that is being pushed by another block.
 pub enum PusheeResult {
+    /// The push is successful, the pushee can move in the direction of the push.
     NotPushed,
+    /// The push was unsuccessful, the pushee cannot move in the direction of the push.
     Pushed,
 }
 
-impl PusheeResult {
-    fn reduce(&self, other: &PusheeResult) -> PusheeResult {
-        match (self, other) {
-            (PusheeResult::NotPushed, PusheeResult::NotPushed) => PusheeResult::NotPushed,
-            _ => PusheeResult::Pushed,
-        }
-    }
-}
-
+/// Abstraction for types that can pushed or be pushed in the context of sokoban.
+///
+/// Essentially defines the rules of the sokoban game.
 pub trait Push {
+    /// Returns the outcome of this instance pushing another.
     fn push(&self, pushee: &Self) -> (PusherResult, PusheeResult);
 }
 
@@ -407,11 +414,6 @@ where
 {
     fn get_coordinate_and_block(&self, entity: &Entity) -> Option<&(IVec2, &'a P)> {
         self.entity_table.get(entity)
-    }
-
-    fn get_coordinate(&self, entity: &Entity) -> Option<&IVec2> {
-        self.get_coordinate_and_block(entity)
-            .map(|(coordinate, _)| coordinate)
     }
 
     fn get_block(&self, entity: &Entity) -> Option<&'a P> {

--- a/src/sokoban.rs
+++ b/src/sokoban.rs
@@ -12,6 +12,7 @@ use bevy::{
 use bevy_easings::*;
 use bevy_ecs_ldtk::{prelude::*, utils::grid_coords_to_translation};
 use std::{
+    hash::Hash,
     marker::PhantomData,
     ops::{Add, AddAssign},
 };
@@ -65,14 +66,14 @@ where
     P: Push + Component,
 {
     fn build(&self, app: &mut App) {
-        app.add_event::<SokobanCommand>()
-            .add_event::<PushEvent>()
+        app.add_event::<SokobanCommand<Direction>>()
+            .add_event::<PushEvent<Direction>>()
             .insert_resource(self.layer_identifier.clone())
             .add_systems(
                 Update,
-                flush_sokoban_commands::<P>
+                flush_sokoban_commands::<P, Direction>
                     .run_if(in_state(self.state.clone()))
-                    .run_if(on_event::<SokobanCommand>())
+                    .run_if(on_event::<SokobanCommand<Direction>>())
                     .in_set(SokobanSets::LogicalMovement),
             )
             // Systems with potential easing end/beginning collisions cannot be in CoreSet::Update
@@ -109,18 +110,20 @@ pub enum Direction {
     Right,
 }
 
-impl From<&Direction> for IVec2 {
-    fn from(direction: &Direction) -> IVec2 {
+impl Add<&Direction> for IVec2 {
+    type Output = IVec2;
+
+    fn add(self, direction: &Direction) -> IVec2 {
         match direction {
-            Direction::Zero => IVec2::ZERO,
-            Direction::UpRight => IVec2::new(1, 1),
-            Direction::Up => IVec2::Y,
-            Direction::UpLeft => IVec2::new(-1, 1),
-            Direction::Left => -IVec2::X,
-            Direction::DownLeft => IVec2::new(-1, -1),
-            Direction::Down => -IVec2::Y,
-            Direction::DownRight => IVec2::new(1, -1),
-            Direction::Right => IVec2::X,
+            Direction::Zero => self + IVec2::ZERO,
+            Direction::UpRight => self + IVec2::new(1, 1),
+            Direction::Up => self + IVec2::Y,
+            Direction::UpLeft => self + IVec2::new(-1, 1),
+            Direction::Left => self - IVec2::X,
+            Direction::DownLeft => self + IVec2::new(-1, -1),
+            Direction::Down => self - IVec2::Y,
+            Direction::DownRight => self + IVec2::new(1, -1),
+            Direction::Right => self + IVec2::X,
         }
     }
 }
@@ -150,7 +153,7 @@ impl TryFrom<&IVec2> for Direction {
 
 impl Direction {
     fn try_add(self, rhs: Direction) -> Result<Direction, OutOfBoundsDirection> {
-        Direction::try_from(&(IVec2::from(&self) + IVec2::from(&rhs)))
+        Direction::try_from(&(IVec2::ZERO + &self + &rhs))
     }
 }
 
@@ -170,27 +173,39 @@ impl AddAssign for Direction {
 
 /// Enumerates commands that can be performed via [SokobanCommands].
 #[derive(Debug, Clone, Event)]
-pub enum SokobanCommand {
+pub enum SokobanCommand<D>
+where
+    for<'d> IVec2: Add<&'d D, Output = IVec2>,
+    D: Hash + PartialEq + Eq + Clone + Send + Sync + 'static,
+{
     /// Move a [SokobanBlock] entity in the given direction.
     Move {
         /// The [SokobanBlock] entity to move.
         entity: Entity,
         /// The direction to move the block in.
-        direction: Direction,
+        direction: D,
     },
 }
 
 /// System parameter providing an interface for commanding the SokobanPlugin.
 #[derive(SystemParam)]
-pub struct SokobanCommands<'w> {
-    writer: EventWriter<'w, SokobanCommand>,
+pub struct SokobanCommands<'w, D>
+where
+    for<'d> IVec2: Add<&'d D, Output = IVec2>,
+    D: Hash + PartialEq + Eq + Clone + Send + Sync + 'static,
+{
+    writer: EventWriter<'w, SokobanCommand<D>>,
 }
 
-impl SokobanCommands<'_> {
+impl<'w, D> SokobanCommands<'w, D>
+where
+    for<'d> IVec2: Add<&'d D, Output = IVec2>,
+    D: Hash + PartialEq + Eq + Clone + Send + Sync + 'static,
+{
     /// Move a [SokobanBlock] entity in the given direction.
     ///
     /// Will perform the necessary collision checks and block pushes.
-    pub fn move_block(&mut self, entity: Entity, direction: Direction) {
+    pub fn move_block(&mut self, entity: Entity, direction: D) {
         self.writer.send(SokobanCommand::Move { entity, direction });
     }
 }
@@ -293,11 +308,15 @@ pub struct PushTracker;
 
 /// Event that fires when a [PushTracker] entity pushes other [SokobanBlock]s.
 #[derive(Debug, Clone, PartialEq, Eq, Hash, Event)]
-pub struct PushEvent {
+pub struct PushEvent<D>
+where
+    for<'d> IVec2: Add<&'d D, Output = IVec2>,
+    D: Hash + PartialEq + Eq + Clone + Send + Sync + 'static,
+{
     /// The [PushTracker] entity that pushed other [SokobanBlock]s.
     pub pusher: Entity,
     /// The direction of the push.
-    pub direction: Direction,
+    pub direction: D,
 }
 
 fn ease_movement(
@@ -392,17 +411,21 @@ where
     }
 
     /// returns a list of entities that would be pushed
-    fn simulate_move_entity(
+    fn simulate_move_entity<D>(
         &self,
         pusher_entity: &Entity,
-        direction: &Direction,
-    ) -> (PusherResult, HashSet<Entity>, HashSet<PushEvent>) {
-        let Some((pusher_coordinate, pusher_block)) = self.get_coordinate_and_block(&pusher_entity)
+        direction: &D,
+    ) -> (PusherResult, HashSet<Entity>, HashSet<PushEvent<D>>)
+    where
+        for<'d> IVec2: Add<&'d D, Output = IVec2>,
+        D: Hash + PartialEq + Eq + Clone + Send + Sync + 'static,
+    {
+        let Some((pusher_coordinate, pusher_block)) = self.get_coordinate_and_block(pusher_entity)
         else {
             return default();
         };
 
-        let destination = *pusher_coordinate + IVec2::from(direction);
+        let destination = *pusher_coordinate + direction;
         if &destination == pusher_coordinate {
             return default();
         }
@@ -450,7 +473,7 @@ where
         if !moved_entities.is_empty() {
             push_events.insert(PushEvent {
                 pusher: *pusher_entity,
-                direction: *direction,
+                direction: direction.clone(),
             });
         }
 
@@ -462,12 +485,14 @@ where
     }
 }
 
-fn flush_sokoban_commands<P>(
+fn flush_sokoban_commands<P, D>(
     mut grid_coords_query: Query<(Entity, &mut GridCoords, &P, Has<PushTracker>)>,
-    mut sokoban_commands: EventReader<SokobanCommand>,
-    mut push_events: EventWriter<PushEvent>,
+    mut sokoban_commands: EventReader<SokobanCommand<D>>,
+    mut push_events: EventWriter<PushEvent<D>>,
 ) where
     P: Push + Component,
+    for<'d> IVec2: Add<&'d D, Output = IVec2>,
+    D: Hash + PartialEq + Eq + Clone + Send + Sync + 'static,
 {
     for sokoban_command in sokoban_commands.read() {
         let SokobanCommand::Move { entity, direction } = sokoban_command;
@@ -481,14 +506,16 @@ fn flush_sokoban_commands<P>(
                 })
                 .collect::<EntityCollisionGeographicMap<P>>();
 
-            entity_collision_geographic_map.simulate_move_entity(&entity, direction)
+            entity_collision_geographic_map.simulate_move_entity(entity, direction)
         };
 
         entities_to_move.iter().for_each(|entity_to_move| {
-            *grid_coords_query
+            let mut grid_coords = grid_coords_query
                 .get_component_mut::<GridCoords>(*entity_to_move)
-                .expect("pushed entity should be valid sokoban entity") +=
-                GridCoords::from(IVec2::from(direction));
+                .expect("pushed entity should be valid sokoban entity");
+
+            let new_coords = IVec2::from(*grid_coords) + direction;
+            *grid_coords = GridCoords::from(new_coords);
         });
 
         push_events_to_send

--- a/src/sokoban.rs
+++ b/src/sokoban.rs
@@ -353,7 +353,7 @@ fn ease_movement(
     }
 }
 
-#[derive(Clone, Default, Debug)]
+#[derive(Clone, Debug)]
 struct EntityCollisionGeographicMap<'a, P>
 where
     P: Push + Component,
@@ -362,13 +362,25 @@ where
     entity_table: HashMap<Entity, (IVec2, &'a P)>,
 }
 
+impl<'a, P> Default for EntityCollisionGeographicMap<'a, P>
+where
+    P: Push + Component,
+{
+    fn default() -> Self {
+        EntityCollisionGeographicMap {
+            coordinate_table: HashMap::new(),
+            entity_table: HashMap::new(),
+        }
+    }
+}
+
 impl<'a, P> FromIterator<(Entity, IVec2, &'a P)> for EntityCollisionGeographicMap<'a, P>
 where
     P: Push + Component,
 {
     fn from_iter<T: IntoIterator<Item = (Entity, IVec2, &'a P)>>(iter: T) -> Self {
         iter.into_iter().fold(
-            Self::new(),
+            Self::default(),
             |EntityCollisionGeographicMap {
                  mut coordinate_table,
                  mut entity_table,
@@ -393,13 +405,6 @@ impl<'a, P> EntityCollisionGeographicMap<'a, P>
 where
     P: Push + Component,
 {
-    fn new() -> Self {
-        EntityCollisionGeographicMap {
-            coordinate_table: HashMap::new(),
-            entity_table: HashMap::new(),
-        }
-    }
-
     fn get_coordinate_and_block(&self, entity: &Entity) -> Option<&(IVec2, &'a P)> {
         self.entity_table.get(entity)
     }

--- a/src/sokoban.rs
+++ b/src/sokoban.rs
@@ -77,9 +77,10 @@ where
 struct SokobanLayerIdentifier(String);
 
 /// Enumerates the four directions that sokoban blocks can be pushed in.
-#[derive(Copy, Clone, Eq, PartialEq, Debug, Hash)]
+#[derive(Copy, Clone, Default, Eq, PartialEq, Debug, Hash)]
 pub enum Direction {
     /// North direction.
+    #[default]
     Up,
     /// West direction.
     Left,

--- a/src/sokoban.rs
+++ b/src/sokoban.rs
@@ -113,6 +113,43 @@ impl From<&Direction> for IVec2 {
     }
 }
 
+#[derive(Debug, Error)]
+#[error("Directions must have coordinates of 0s and 1s")]
+pub struct OutOfBoundsDirection;
+
+impl TryFrom<&IVec2> for Direction {
+    type Error = OutOfBoundsDirection;
+
+    fn try_from(value: &IVec2) -> Result<Direction, OutOfBoundsDirection> {
+        match (value.x, value.y) {
+            (0, 0) => Ok(Direction::Zero),
+            (1, 1) => Ok(Direction::UpRight),
+            (0, 1) => Ok(Direction::Up),
+            (-1, 1) => Ok(Direction::UpLeft),
+            (-1, 0) => Ok(Direction::Left),
+            (-1, -1) => Ok(Direction::DownLeft),
+            (0, -1) => Ok(Direction::Down),
+            (1, -1) => Ok(Direction::DownRight),
+            (1, 0) => Ok(Direction::Right),
+            _ => Err(OutOfBoundsDirection),
+        }
+    }
+}
+
+impl Direction {
+    fn try_add(self, rhs: Direction) -> Result<Direction, OutOfBoundsDirection> {
+        Direction::try_from(&(IVec2::from(&self) + IVec2::from(&rhs)))
+    }
+}
+
+impl Add<Direction> for Direction {
+    type Output = Direction;
+
+    fn add(self, rhs: Direction) -> Self::Output {
+        self.try_add(rhs).unwrap()
+    }
+}
+
 /// Enumerates commands that can be performed via [SokobanCommands].
 #[derive(Debug, Clone, Event)]
 pub enum SokobanCommand {

--- a/src/sokoban.rs
+++ b/src/sokoban.rs
@@ -318,129 +318,161 @@ fn ease_movement(
     }
 }
 
-type CollisionMap = Vec<Vec<Option<(Entity, SokobanBlock)>>>;
+type CollisionMap = Vec<Vec<HashMap<Entity, SokobanBlock>>>;
 
-/// Pushes the entry at the given coordinates in the collision_map in the given direction.
-///
-/// If possible, it will also push any entries it collides with.
-///
-/// # Returns
-/// Returns a tuple containing the updated collision_map, and an optional list of pushed entities.
-///
-/// If the optional list is `None`, no entities were pushed due to collision with either a
-/// [SokobanBlock::Static] entry or a boundary of the map.
-///
-/// If the optional list is empty, no entities were pushed due to the provided coordinates pointing
-/// to an empty entry. This distinction is important for the recursive algorithm.
-fn push_collision_map_entry(
-    collision_map: CollisionMap,
-    pusher_coords: IVec2,
-    direction: Direction,
-) -> (CollisionMap, Option<Vec<Entity>>) {
-    // check if pusher is out-of-bounds
-    if pusher_coords.x < 0
-        || pusher_coords.y < 0
-        || pusher_coords.y as usize >= collision_map.len()
-        || pusher_coords.x as usize >= collision_map[0].len()
-    {
-        // no updates to collision_map, no pushes can be performed
-        return (collision_map, None);
+#[derive(Clone, Default, Debug)]
+struct EntityCollisionGeographicMap {
+    coordinate_table: HashMap<IVec2, HashSet<Entity>>,
+    entity_table: HashMap<Entity, (IVec2, SokobanBlock)>,
+}
+
+impl<'a> FromIterator<(Entity, IVec2, SokobanBlock)> for EntityCollisionGeographicMap {
+    fn from_iter<T: IntoIterator<Item = (Entity, IVec2, SokobanBlock)>>(iter: T) -> Self {
+        iter.into_iter().fold(
+            default(),
+            |EntityCollisionGeographicMap {
+                 mut coordinate_table,
+                 mut entity_table,
+             },
+             (entity, coordinate, push_block)| {
+                coordinate_table
+                    .entry(coordinate)
+                    .or_default()
+                    .insert(entity);
+                entity_table.insert(entity, (coordinate, push_block));
+
+                EntityCollisionGeographicMap {
+                    coordinate_table,
+                    entity_table,
+                }
+            },
+        )
+    }
+}
+
+impl EntityCollisionGeographicMap {
+    fn get_coordinate_and_block(&self, entity: &Entity) -> Option<&(IVec2, SokobanBlock)> {
+        self.entity_table.get(entity)
     }
 
-    // match against the pusher's CollisionMap entry
-    match collision_map[pusher_coords.y as usize][pusher_coords.x as usize] {
-        Some((pusher, SokobanBlock::Dynamic)) => {
-            // pusher is dynamic, so we try to push
-            let destination = pusher_coords + IVec2::from(&direction);
+    fn get_coordinate(&self, entity: &Entity) -> Option<&IVec2> {
+        self.get_coordinate_and_block(entity)
+            .map(|(coordinate, _)| coordinate)
+    }
 
-            match push_collision_map_entry(collision_map, destination, direction) {
-                (mut collision_map, Some(mut pushed_entities)) => {
-                    // destination is either empty or has been pushed, so we can push the pusher
-                    collision_map[destination.y as usize][destination.x as usize] =
-                        collision_map[pusher_coords.y as usize][pusher_coords.x as usize].take();
-                    pushed_entities.push(pusher);
+    fn get_block(&self, entity: &Entity) -> Option<&SokobanBlock> {
+        self.get_coordinate_and_block(entity)
+            .map(|(_, block)| block)
+    }
 
-                    (collision_map, Some(pushed_entities))
-                }
-                // destination can't be pushed, so the pusher can't be pushed either
-                none_case => none_case,
-            }
+    fn get_entities_at_coords(&self, coordinate: &IVec2) -> Option<&HashSet<Entity>> {
+        self.coordinate_table.get(coordinate)
+    }
+
+    /// returns a list of entities that would be pushed
+    fn simulate_move_entity(
+        &self,
+        pusher_entity: &Entity,
+        direction: &Direction,
+    ) -> (PusherResult, HashSet<Entity>, HashSet<PushEvent>) {
+        let Some((pusher_coordinate, pusher_block)) = self.get_coordinate_and_block(&pusher_entity)
+        else {
+            return default();
+        };
+
+        let destination = *pusher_coordinate + IVec2::from(direction);
+
+        let (pusher_result, mut moved_entities, mut push_events) = self
+            .get_entities_at_coords(&destination)
+            .iter()
+            .copied()
+            .flatten()
+            .map(|pushee_entity| {
+                let pushee_block = self
+                    .get_block(pushee_entity)
+                    .expect("entities in coordinate table should also exist in entity table");
+
+                let (our_pusher_result, pushee_result) = pusher_block.push(pushee_block);
+
+                let (their_pusher_result, moved_entities, push_events) = match pushee_result {
+                    PusheeResult::Pushed => self.simulate_move_entity(pushee_entity, direction),
+                    PusheeResult::NotPushed => default(),
+                };
+
+                let pusher_result = our_pusher_result.reduce(&their_pusher_result);
+
+                (pusher_result, moved_entities, push_events)
+            })
+            .reduce(
+                |(
+                    previous_pusher_result,
+                    mut previous_moved_entities,
+                    mut previous_push_events,
+                ),
+                 (pusher_result, moved_entities, push_events)| {
+                    previous_moved_entities.extend(moved_entities);
+                    previous_push_events.extend(push_events);
+
+                    (
+                        previous_pusher_result.reduce(&pusher_result),
+                        previous_moved_entities,
+                        previous_push_events,
+                    )
+                },
+            )
+            .unwrap_or_default();
+
+        if !moved_entities.is_empty() {
+            push_events.insert(PushEvent {
+                pusher: *pusher_entity,
+                direction: *direction,
+            });
         }
-        // pusher is static, no pushes can be performed
-        Some((_, SokobanBlock::Static)) => (collision_map, None),
-        // pusher's entry is empty, no push is performed here but the caller is able to
-        None => (collision_map, Some(Vec::new())),
+
+        if pusher_result == PusherResult::NotBlocked {
+            moved_entities.insert(*pusher_entity);
+        }
+
+        (pusher_result, moved_entities, push_events)
     }
 }
 
 fn flush_sokoban_commands(
-    mut grid_coords_query: Query<(Entity, &mut GridCoords, &SokobanBlock, Option<&PushTracker>)>,
+    mut grid_coords_query: Query<(Entity, &mut GridCoords, &SokobanBlock, Has<PushTracker>)>,
     mut sokoban_commands: EventReader<SokobanCommand>,
     mut push_events: EventWriter<PushEvent>,
-    layers: Query<&LayerMetadata>,
-    layer_id: Res<SokobanLayerIdentifier>,
 ) {
-    // Get dimensions of the currently-loaded level
-    if let Some(LayerMetadata { c_wid, c_hei, .. }) =
-        layers.iter().find(|l| l.identifier == **layer_id)
-    {
-        // Generate current collision map
-        let mut collision_map: CollisionMap = vec![vec![None; *c_wid as usize]; *c_hei as usize];
+    for sokoban_command in sokoban_commands.read() {
+        // regenerate map per command to get map updates from previous command
+        let entity_collision_geographic_map = grid_coords_query
+            .iter()
+            .map(|(entity, grid_coords, sokoban_block, _)| {
+                (entity, IVec2::from(*grid_coords), *sokoban_block)
+            })
+            .collect::<EntityCollisionGeographicMap>();
 
-        for (entity, grid_coords, sokoban_block, _) in grid_coords_query.iter_mut() {
-            collision_map[grid_coords.y as usize][grid_coords.x as usize] =
-                Some((entity, *sokoban_block));
-        }
+        let SokobanCommand::Move { entity, direction } = sokoban_command;
 
-        for sokoban_command in sokoban_commands.read() {
-            let SokobanCommand::Move { entity, direction } = sokoban_command;
+        let (_, entities_to_move, push_events_to_send) =
+            entity_collision_geographic_map.simulate_move_entity(&entity, &direction);
 
-            if let Ok((_, grid_coords, ..)) = grid_coords_query.get(*entity) {
-                // Determine if move can happen, who moves, how the collision_map should be
-                // updated...
-                let (new_collision_map, pushed_entities) =
-                    push_collision_map_entry(collision_map, IVec2::from(*grid_coords), *direction);
+        entities_to_move.iter().for_each(|entity_to_move| {
+            *grid_coords_query
+                .get_component_mut::<GridCoords>(*entity_to_move)
+                .expect("pushed entity should be valid sokoban entity") +=
+                GridCoords::from(IVec2::from(direction));
+        });
 
-                collision_map = new_collision_map;
+        push_events_to_send
+            .into_iter()
+            .filter(|push_event| {
+                let (.., is_push_tracker) = grid_coords_query
+                    .get(push_event.pusher)
+                    .expect("entity source from query should still exist in query");
 
-                if let Some(mut pushed_entities) = pushed_entities {
-                    pushed_entities.reverse();
-
-                    // update GridCoords components of pushed entities
-                    for pushed_entity in &pushed_entities {
-                        *grid_coords_query
-                            .get_component_mut::<GridCoords>(*pushed_entity)
-                            .expect("pushed entity should be valid sokoban entity") +=
-                            GridCoords::from(IVec2::from(direction));
-                    }
-
-                    // send push events
-                    for (i, pusher) in pushed_entities.iter().enumerate() {
-                        let pushed = &pushed_entities[i + 1..];
-
-                        if !pushed.is_empty() {
-                            if let (.., Some(_)) = grid_coords_query
-                                .get(*pusher)
-                                .expect("pusher should be valid sokoban entity")
-                            {
-                                push_events.send(PushEvent {
-                                    pusher: *pusher,
-                                    direction: *direction,
-                                    pushed: pushed.into(),
-                                });
-                            }
-                        }
-                    }
-                }
-            } else {
-                warn!("attempted to move sokoban entity {entity:?}, but it does not exist or is malformed")
-            }
-        }
-    } else {
-        warn!(
-            "could not find {} layer specified by SokobanLayerIdentifier resource",
-            **layer_id
-        );
+                is_push_tracker
+            })
+            .for_each(|push_event| push_events.send(push_event));
     }
 }
 

--- a/src/sokoban.rs
+++ b/src/sokoban.rs
@@ -28,20 +28,25 @@ pub enum SokobanSets {
 }
 
 /// Plugin providing functionality for sokoban-style movement and collision to LDtk levels.
-pub struct SokobanPlugin<S, P>
+pub struct SokobanPlugin<S, P, D>
 where
     S: States,
     P: Push + Component,
+    for<'d> IVec2: Add<&'d D, Output = IVec2>,
+    D: Hash + PartialEq + Eq + Clone + Send + Sync + 'static,
 {
     state: S,
     layer_identifier: SokobanLayerIdentifier,
     phantom_push_component: PhantomData<P>,
+    phantom_direction: PhantomData<D>,
 }
 
-impl<S, P> SokobanPlugin<S, P>
+impl<S, P, D> SokobanPlugin<S, P, D>
 where
     S: States,
     P: Push + Component,
+    for<'d> IVec2: Add<&'d D, Output = IVec2>,
+    D: Hash + PartialEq + Eq + Clone + Send + Sync + 'static,
 {
     /// Constructor for the plugin.
     ///
@@ -56,14 +61,17 @@ where
             state,
             layer_identifier,
             phantom_push_component: PhantomData,
+            phantom_direction: PhantomData,
         }
     }
 }
 
-impl<S, P> Plugin for SokobanPlugin<S, P>
+impl<S, P, D> Plugin for SokobanPlugin<S, P, D>
 where
     S: States,
     P: Push + Component,
+    for<'d> IVec2: Add<&'d D, Output = IVec2>,
+    D: Hash + PartialEq + Eq + Clone + Send + Sync + 'static,
 {
     fn build(&self, app: &mut App) {
         app.add_event::<SokobanCommand<Direction>>()

--- a/src/sokoban.rs
+++ b/src/sokoban.rs
@@ -381,6 +381,9 @@ impl EntityCollisionGeographicMap {
         };
 
         let destination = *pusher_coordinate + IVec2::from(direction);
+        if &destination == pusher_coordinate {
+            return default();
+        }
 
         let (pusher_result, mut moved_entities, mut push_events) = self
             .get_entities_at_coords(&destination)

--- a/src/sokoban.rs
+++ b/src/sokoban.rs
@@ -326,8 +326,6 @@ fn ease_movement(
     }
 }
 
-type CollisionMap = Vec<Vec<HashMap<Entity, SokobanBlock>>>;
-
 #[derive(Clone, Default, Debug)]
 struct EntityCollisionGeographicMap<'a, P>
 where


### PR DESCRIPTION
Movable arrow blocks requires some changes to the sokoban plugin. The main change is expanding the possible directions that pushers and blocks can move in. These changes not only accomplish that, but also make a lot of changes to the sokoban plugin code to make it more generic. It is now generic over the component that the sokoban is concerned with, and the directions that it can go in. The traits of these generics define the rules of the sokoban game. The hope is that the flexibility of the plugin would make it easy to extract and release as its own crate someday.

This change is a bit large, but I'm making some compromises to the perfection of these commits to get #167 (which has been in draft for almost a year), finally merged.

