### PR TITLE
feat: add GraveyardLayer for LDtk layer representation and utility

### DIFF
--- a/src/graveyard/layer.rs
+++ b/src/graveyard/layer.rs
@@ -1,18 +1,28 @@
+//! Utilities related to the graveyard's LDtk layers.
+
 use bevy::prelude::*;
 use bevy_ecs_ldtk::prelude::*;
 use thiserror::Error;
 
+/// Layer entity does not exist.
 #[derive(Debug, Error)]
 #[error("{0:?} layer entity does not exist.")]
 pub struct LayerEntityDoesNotExist(GraveyardLayer);
 
+/// All LDtk layers in graveyard levels.
 #[derive(Copy, Clone, Debug, PartialEq, Eq)]
 pub enum GraveyardLayer {
+    /// The background layer, usually for ground textures.
     Background,
+    /// Another background layer, specifically for border textures that should appear behind willo.
     BorderBackground,
+    /// Another background layer, but for entities that should appear behind willo.
     BackgroundEntities,
+    /// Layer for gameplay tiles, like walls and volatile textures.
     IntGrid,
+    /// Layer for sokoban entities, like willo and pushable blocks.
     Entities,
+    /// Layer for things that appear infront of willo, like certain parts of border textures.
     Foreground,
 }
 
@@ -35,6 +45,7 @@ impl GraveyardLayer {
         }
     }
 
+    /// Returns a system that takes a pipe input of bundles and spawns them on this layer.
     pub fn spawn_bundles_on<I>(
         self,
     ) -> impl Fn(In<I>, Commands, Query<(Entity, &LayerMetadata)>) -> Result<(), LayerEntityDoesNotExist>

--- a/src/graveyard/layer.rs
+++ b/src/graveyard/layer.rs
@@ -1,0 +1,58 @@
+use bevy::prelude::*;
+use bevy_ecs_ldtk::prelude::*;
+use thiserror::Error;
+
+#[derive(Debug, Error)]
+#[error("{0:?} layer entity does not exist.")]
+pub struct LayerEntityDoesNotExist(GraveyardLayer);
+
+#[derive(Copy, Clone, Debug, PartialEq, Eq)]
+pub enum GraveyardLayer {
+    Background,
+    BorderBackground,
+    BackgroundEntities,
+    IntGrid,
+    Entities,
+    Foreground,
+}
+
+impl GraveyardLayer {
+    const BACKGROUND_IDENTIFIER: &'static str = "Background";
+    const BORDER_BACKGROUND_IDENTIFIER: &'static str = "BorderBG";
+    const BACKGROUND_ENTITIES_IDENTIFIER: &'static str = "Background_Entities";
+    const INT_GRID_IDENTIFIER: &'static str = "IntGrid";
+    const ENTITIES_IDENTIFIER: &'static str = "Entities";
+    const FOREGROUND_IDENTIFIER: &'static str = "ForeGround";
+
+    fn as_identifier(&self) -> &'static str {
+        match self {
+            GraveyardLayer::Background => Self::BACKGROUND_IDENTIFIER,
+            GraveyardLayer::BorderBackground => Self::BORDER_BACKGROUND_IDENTIFIER,
+            GraveyardLayer::BackgroundEntities => Self::BACKGROUND_ENTITIES_IDENTIFIER,
+            GraveyardLayer::IntGrid => Self::INT_GRID_IDENTIFIER,
+            GraveyardLayer::Entities => Self::ENTITIES_IDENTIFIER,
+            GraveyardLayer::Foreground => Self::FOREGROUND_IDENTIFIER,
+        }
+    }
+
+    pub fn spawn_bundles_on<I>(
+        self,
+    ) -> impl Fn(In<I>, Commands, Query<(Entity, &LayerMetadata)>) -> Result<(), LayerEntityDoesNotExist>
+    where
+        I: IntoIterator,
+        <I as IntoIterator>::Item: Bundle,
+    {
+        move |In(bundles_iter), mut commands, layer_query| {
+            let (layer_entity, _) = layer_query
+                .iter()
+                .find(|(_, metadata)| metadata.identifier == self.as_identifier())
+                .ok_or(LayerEntityDoesNotExist(self))?;
+
+            bundles_iter.into_iter().for_each(|bundle| {
+                commands.spawn(bundle).set_parent(layer_entity);
+            });
+
+            Ok(())
+        }
+    }
+}

--- a/src/graveyard/mod.rs
+++ b/src/graveyard/mod.rs
@@ -6,6 +6,7 @@ pub mod control_display;
 pub mod exorcism;
 pub mod goal;
 pub mod gravestone;
+pub mod layer;
 pub mod movement_table;
 pub mod out_of_bounds;
 pub mod volatile;


### PR DESCRIPTION
There have been a couple of occasions now where we want to interact with the LDtk layers of the graveyard levels. In particular, it's pretty common that we basically want to spawn entites on a particular layer. This adds a utility for logically enumerating the layers of the graveyard LDtk project, from which utilities can be built. One such utility has been provided: a higher-order function that returns a system that can spawn bundles (as pipe input) on a given layer.
