### PR TITLE
fix: downgrade dependencies in wasm target to limit getrandom to 0.2

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -29,3 +29,8 @@ itertools = "0.12.1"
 
 [target.wasm32-unknown-unknown.dependencies]
 bevy_ecs_ldtk = { version = "0.9", default-features = false, features = ["derive", "render", "external_levels", "atlas"] }
+# While we don't depend on these directly, some bevy dependencies do, and they
+# both upgraded their getrandom dependency in their proceeding releases in a
+# way that broke wasm compatibility
+uuid = "=1.12.1"
+ahash = "=0.8.11"


### PR DESCRIPTION
getrandom 0.3 requires a different set of feature flags to be enabled for wasm compaitibility. Some dependencies of dependencies depend on getrandom, and upgraded to getrandom 0.3 in a way that breaks bevy's wasm compatibility. This leads to wasm build failures in our CI. Limiting these sub-dependencies to versions that merely depend on getrandom 0.2 should resolve the issue.
