### PR TITLE
ci: run version CI against all merges instead of daily

### DIFF
--- a/.github/workflows/version.yaml
+++ b/.github/workflows/version.yaml
@@ -1,11 +1,9 @@
 name: Version
 
-# The goal is to have this run at midnight in Denver
-# This requires us to use two crons due to daylight savings
 on:
-  schedule:
-    - cron: '0 7 * 1,2,11,12 *'
-    - cron: '0 6 * 3,4,5,6,7,8,9,10 *'
+  pushes:
+    branches:
+      - 'main'
   workflow_dispatch:
 
 jobs:
@@ -58,7 +56,7 @@ jobs:
                 echo "updating cargo"
                 sed "s/^version = \".*\"$/version = \"$CODE_VERSION\"/" Cargo.toml -i
                 git add Cargo.toml
-                git commit -m "build: increment version to $CODE_VERSION"
+                git commit -m "build: increment version to $CODE_VERSION [skip ci]"
               fi
 
               DATE_VERSION=$(date +%y.%m.%d)


### PR DESCRIPTION
Originally, I had the version CI that tags versions of the game and triggers releases running daily. I thought this might be more efficient than performing it on every merge. However, most daily attempts to create new versions are no-ops that still take up github runner resources, to the point that github disables our CI. This switches to a release on every merge instead.

An attempt is being made here to not recursively trigger the version CI workflow when the commit to increase the version in the Cargo.toml is pushed. However, it's possible that this will also cause the release CI to be skipped. We will test this live.
