### PR TITLE
ci: fix push typo in version CI

### DIFF
--- a/.github/workflows/version.yaml
+++ b/.github/workflows/version.yaml
@@ -1,7 +1,7 @@
 name: Version
 
 on:
-  pushes:
+  push:
     branches:
       - 'main'
   workflow_dispatch:


### PR DESCRIPTION
The version CI was recently updated to execute on all pushes to main. However, there was a typo in this change, which has been addressed here.
