### PR TITLE
fix: only skip version CI in commits made by version CI

### DIFF
--- a/.github/workflows/version.yaml
+++ b/.github/workflows/version.yaml
@@ -10,6 +10,7 @@ jobs:
   version:
     name: Update Version
     runs-on: ubuntu-latest
+    if: "!contains(github.event.head_commit.message, '[version ci]')"
     steps:
       - uses: actions/checkout@v2
         with:
@@ -56,7 +57,7 @@ jobs:
                 echo "updating cargo"
                 sed "s/^version = \".*\"$/version = \"$CODE_VERSION\"/" Cargo.toml -i
                 git add Cargo.toml
-                git commit -m "build: increment version to $CODE_VERSION [skip ci]"
+                git commit -m "build: increment version to $CODE_VERSION [version ci]"
               fi
 
               DATE_VERSION=$(date +%y.%m.%d)


### PR DESCRIPTION
An attempt was made to avoid recursively processing commits pushed to main in the version CI by using github's skip ci feature. However, this also prevents the release ci from running on these commits, which is not the behavior we want. This change implements a more custom solution that uses and checks for a more specific message in the commits that the version CI creates/should skip.
