### PR TITLE
feat: add GravestoneMovementQueries system param

### DIFF
--- a/src/graveyard/gravestone_movement_queries.rs
+++ b/src/graveyard/gravestone_movement_queries.rs
@@ -1,0 +1,24 @@
+use bevy::{ecs::system::SystemParam, prelude::*};
+use bevy_ecs_ldtk::prelude::*;
+
+use crate::graveyard::{arrow_block::MovementTile, gravestone::GraveId};
+
+#[derive(Debug, SystemParam)]
+pub struct GravestoneMovementQueries<'w, 's> {
+    gravestones: Query<'w, 's, (&'static GridCoords, &'static GraveId)>,
+    movement_tiles: Query<'w, 's, (&'static GridCoords, &'static MovementTile)>,
+}
+
+impl<'w, 's> GravestoneMovementQueries<'w, 's> {
+    pub fn find_movement(&self, grave_id: &GraveId) -> Option<&MovementTile> {
+        self.gravestones
+            .iter()
+            .find(|(_, this_grave_id)| &grave_id == this_grave_id)
+            .and_then(|(grid_coords, _)| {
+                self.movement_tiles
+                    .iter()
+                    .find(|(this_grid_coords, _)| &grid_coords == this_grid_coords)
+            })
+            .map(|(_, movement_tile)| movement_tile)
+    }
+}

--- a/src/graveyard/gravestone_movement_queries.rs
+++ b/src/graveyard/gravestone_movement_queries.rs
@@ -3,9 +3,11 @@ use bevy_ecs_ldtk::prelude::*;
 
 use crate::graveyard::{arrow_block::MovementTile, gravestone::GraveId};
 
+use super::volatile::Volatile;
+
 #[derive(Debug, SystemParam)]
 pub struct GravestoneMovementQueries<'w, 's> {
-    gravestones: Query<'w, 's, (&'static GridCoords, &'static GraveId)>,
+    gravestones: Query<'w, 's, (&'static GridCoords, &'static GraveId, &'static Volatile)>,
     movement_tiles: Query<'w, 's, (&'static GridCoords, &'static MovementTile)>,
 }
 
@@ -13,8 +15,10 @@ impl<'w, 's> GravestoneMovementQueries<'w, 's> {
     pub fn find_movement(&self, grave_id: &GraveId) -> Option<&MovementTile> {
         self.gravestones
             .iter()
-            .find(|(_, this_grave_id)| &grave_id == this_grave_id)
-            .and_then(|(grid_coords, _)| {
+            .find(|(_, this_grave_id, volatile)| {
+                **volatile == Volatile::Solid && &grave_id == this_grave_id
+            })
+            .and_then(|(grid_coords, ..)| {
                 self.movement_tiles
                     .iter()
                     .find(|(this_grid_coords, _)| &grid_coords == this_grid_coords)

--- a/src/graveyard/gravestone_movement_queries.rs
+++ b/src/graveyard/gravestone_movement_queries.rs
@@ -1,3 +1,4 @@
+//! Contains the [`GravestoneMovementQueries`] system param, for finding available movements.
 use bevy::{ecs::system::SystemParam, prelude::*};
 use bevy_ecs_ldtk::prelude::*;
 
@@ -5,6 +6,7 @@ use crate::graveyard::{arrow_block::MovementTile, gravestone::GraveId};
 
 use super::volatile::Volatile;
 
+/// System param that can be used to find available movements.
 #[derive(Debug, SystemParam)]
 pub struct GravestoneMovementQueries<'w, 's> {
     gravestones: Query<'w, 's, (&'static GridCoords, &'static GraveId, &'static Volatile)>,
@@ -12,6 +14,7 @@ pub struct GravestoneMovementQueries<'w, 's> {
 }
 
 impl<'w, 's> GravestoneMovementQueries<'w, 's> {
+    /// Resturns the movement associated with the given [`GraveId`], if it has one.
     pub fn find_movement(&self, grave_id: &GraveId) -> Option<&MovementTile> {
         self.gravestones
             .iter()

--- a/src/graveyard/mod.rs
+++ b/src/graveyard/mod.rs
@@ -7,6 +7,7 @@ pub mod control_display;
 pub mod exorcism;
 pub mod goal;
 pub mod gravestone;
+pub mod gravestone_movement_queries;
 pub mod layer;
 pub mod movement_table;
 pub mod out_of_bounds;


### PR DESCRIPTION
A new mechanic is being added: arrow blocks. The movement table will no longer be static, rather, the rows and columns that its cells belong to will be defined by the location of arrow blocks. This adds a system param related to this feature: GravestoneMovementQueries. The method provided on this system param will help reduce repeated code between plugins that need to figure out what movements are associated with what gravestones. This system param is not actually employed in the code yet, all of the preparation for arrow blocks will be completed incrementally, and a final change will replace the existing behavior wholesale.
