### PR TITLE
fix: add missing styles.css file

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -18,11 +18,11 @@ bevy = { version = "0.12", features = ["wav"] }
 bevy_easings = "0.12"
 bevy_ecs_ldtk = { version = "0.9", default-features = false, features = ["derive", "render", "external_levels"] }
 bevy_ecs_tilemap = "0.12"
+bevy_asset_loader = { version = "0.19", features = ["2d"] }
+bevy-inspector-egui = { version = "0.22", optional = true }
 rand = "0.8"
 serde = "1"
 serde_json = "1"
-bevy_asset_loader = { version = "0.19", features = ["2d"] }
-bevy-inspector-egui = { version = "0.22", optional = true }
 thiserror = "1"
 leafwing-input-manager = "0.11"
 itertools = "0.12.1"

--- a/styles.css
+++ b/styles.css
@@ -1,0 +1,53 @@
+body, html {
+    height: 100%;
+}
+
+body {
+    background-color: lightgray;
+    margin: 0;
+    display: flex;
+    justify-content: center;
+    align-items: center;
+}
+
+.game-container {
+    width: 100%;
+    height: 100%;
+    display: flex;
+    justify-content: center;
+    align-items: center;
+}
+
+.lds-dual-ring {
+    display: inline-block;
+    position: absolute;
+    left: 0;
+    right: 0;
+    margin: auto;
+    width: 80px;
+    height: 80px;
+}
+
+.lds-dual-ring:after {
+    content: " ";
+    display: block;
+    width: 64px;
+    height: 64px;
+    border-radius: 50%;
+    border: 6px solid #fff;
+    border-color: #fff transparent #fff transparent;
+    animation: lds-dual-ring 1.2s linear infinite;
+}
+
+@keyframes lds-dual-ring {
+    0% {
+        transform: rotate(0deg);
+    }
+    100% {
+        transform: rotate(360deg);
+    }
+}
+
+#bevy {
+    z-index: 2;
+}


### PR DESCRIPTION
The index file for browser builds was recently changed in an attempt to get browser deployments working again. It now depends on a styles.css file. However, I forgot to add this file when making the change. This change adds that file, as well as make a dummy change to the Cargo.toml to trigger all the necessary build processes on merge.
